### PR TITLE
Support hitting checkpoint urls that use SNI - like dashboard.ophan.co.uk

### DIFF
--- a/app/lib/okhttpscala/package.scala
+++ b/app/lib/okhttpscala/package.scala
@@ -1,0 +1,31 @@
+package lib
+
+import java.io.IOException
+
+import com.squareup.okhttp.{Callback, OkHttpClient, Request, Response}
+
+import scala.concurrent.{Future, Promise}
+
+
+package object okhttpscala {
+
+  implicit class RickOkHttpClient(client: OkHttpClient) {
+
+    def execute(request: Request): Future[Response] = {
+      val p = Promise[Response]()
+
+      client.newCall(request).enqueue(new Callback {
+        override def onFailure(request: Request, e: IOException) {
+          p.failure(e)
+        }
+
+        override def onResponse(response: Response) {
+          p.success(response)
+        }
+      })
+
+      p.future
+    }
+
+  }
+}

--- a/test/FunctionalSpec.scala
+++ b/test/FunctionalSpec.scala
@@ -1,6 +1,10 @@
+import lib.Config.{CheckpointDetails, Checkpoint}
 import lib.Implicits._
 import lib._
 import org.eclipse.jgit.lib.ObjectId.zeroId
+import org.joda.time.Period
+
+import com.netaporter.uri.dsl._
 
 class FunctionalSpec extends Helpers {
 
@@ -43,6 +47,13 @@ class FunctionalSpec extends Helpers {
 
       scan(shouldAddComment = true) {
         _.labelNames must contain only ("Seen-on-PROD")
+      }
+    }
+
+    "be able to hit Ophan" in {
+      val checkpoint = Checkpoint("PROD", CheckpointDetails("https://dashboard.ophan.co.uk/login", Period.parse("PT1H")))
+      whenReady(CheckpointSnapshot(checkpoint)) { s =>
+        s must not be 'empty
       }
     }
   }


### PR DESCRIPTION
Prout was unable to hit https://dashboard.ophan.co.uk/login because that server uses Server Name Indication (SNI) - and Play's WS lib is currently based on a (pre 1.9.0) version of async-http-client that doesn't support SNI. The latest version of AHC supports SNI but unfortunately it's not binary compatible with the earlier version currently used by Play.

OkHttp is an HTTP library that _does_ have SNI support (and Prout is already using it for it's disk-based caching on GitHub API requests):

http://square.github.io/okhttp/

```
"OkHttp initiates new connections with modern TLS features (SNI, ALPN),
and falls back to SSLv3 if the handshake fails."
```

Testing whether a server is using SNI:

http://blog.chrismeller.com/testing-sni-certificates-with-openssl

```
$ openssl s_client -servername dashboard.ophan.co.uk -connect dashboard.ophan.co.uk:443 -prexit
$ openssl s_client -connect dashboard.ophan.co.uk:443 -prexit
```

This should make https://github.com/guardian/ophan/pull/729 work now! I've added a functional test for hitting the Ophan endpoint.

cc @philwills 
