### PR TITLE
Add Slack support - report deployed pull-requests to a Slack channel

### DIFF
--- a/app/lib/slack/DeployReporter.scala
+++ b/app/lib/slack/DeployReporter.scala
@@ -1,0 +1,47 @@
+package lib.slack
+
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import com.netaporter.uri.Uri
+import com.netaporter.uri.dsl._
+import lib.Implicits._
+import lib.{PullRequestCheckpointsSummary, Seen}
+import play.api.Logger
+import play.api.libs.json.Json
+import play.api.libs.ws.WS
+import play.api.Play.current
+
+object DeployReporter {
+
+  def report(snapshot: PullRequestCheckpointsSummary, hooks: Seq[Uri]) {
+    val slackHooks = hooks.filter(_.host.contains("hooks.slack.com"))
+    if (slackHooks.nonEmpty) {
+      for (changedSnapshots <- snapshot.changedSnapshotsByState.get(Seen)) {
+        val pr = snapshot.pr
+        val mergedBy = pr.getMergedBy
+        val checkpoints = changedSnapshots.map(_.checkpoint)
+        val attachments = Seq(Attachment(s"PR #${pr.getNumber} deployed to ${checkpoints.map(_.name).mkString(", ")}",
+          Seq(
+            Attachment.Field("PR", s"<${pr.getUrl}|#${pr.getNumber}>", true),
+            Attachment.Field("Merged by", s"<${mergedBy.getHtmlUrl}|${mergedBy.atLogin}>", true)
+          )
+        ))
+
+        val checkpointsAsSlack = checkpoints.map(c => s"<${c.details.url}|${c.name}>").mkString(", ")
+        val json = Json.toJson(
+          Message(
+            s"*Deployed to $checkpointsAsSlack: ${pr.getTitle}*\n\n${pr.getBody}",
+            Some(lib.Bot.user.getLogin),
+            Some(mergedBy.getAvatarUrl),
+            attachments
+          )
+        )
+
+        for (hook <- slackHooks) {
+          WS.url(hook).post(json).onComplete {
+            r => Logger.debug(s"Response from Slack: ${r.map(_.body)}")
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/lib/slack/package.scala
+++ b/app/lib/slack/package.scala
@@ -1,0 +1,19 @@
+package lib
+
+import play.api.libs.json.Json
+
+package object slack {
+
+  case class Attachment(fallback: String, fields: Seq[Attachment.Field])
+
+  object Attachment {
+    case class Field(title: String, value: String, short: Boolean)
+
+    implicit val writesField = Json.writes[Field]
+    implicit val writesAttachment = Json.writes[Attachment]
+  }
+
+  case class Message(text: String, username: Option[String], icon_url: Option[String], attachments: Seq[Attachment])
+
+  implicit val writesMessage = Json.writes[Message]
+}

--- a/test/FunctionalSpec.scala
+++ b/test/FunctionalSpec.scala
@@ -1,10 +1,12 @@
-import lib.Config.{CheckpointDetails, Checkpoint}
+import com.netaporter.uri.dsl._
+import lib.Config.{Checkpoint, CheckpointDetails}
 import lib.Implicits._
 import lib._
 import org.eclipse.jgit.lib.ObjectId.zeroId
 import org.joda.time.Period
+import org.kohsuke.github.GHEvent
 
-import com.netaporter.uri.dsl._
+import scala.collection.convert.wrapAll._
 
 class FunctionalSpec extends Helpers {
 
@@ -42,6 +44,25 @@ class FunctionalSpec extends Helpers {
       }
 
       scanShouldNotChangeAnything()
+
+      repoPR setCheckpointTo "master"
+
+      scan(shouldAddComment = true) {
+        _.labelNames must contain only ("Seen-on-PROD")
+      }
+    }
+
+    "report slackishly" in {
+
+      val pr = conn().getRepository("guardian/membership-frontend").getPullRequest(15)
+      val prText = PRText(pr.getTitle, pr.getBody)
+
+      implicit val repoPR = mergePullRequestIn("/feature-branches.top-level-config.git.zip", "feature-1", prText)
+
+      for (slackWebhookUrl <- slackWebhookUrlOpt) {
+        repoPR.githubRepo.createWebHook(slackWebhookUrl, Set(GHEvent.WATCH)) // Don't really want the hook to fire!
+        eventually(repoPR.githubRepo.getHooks must not be empty)
+      }
 
       repoPR setCheckpointTo "master"
 


### PR DESCRIPTION
Users can configure a Slack hook for prout by creating a new Slack 'Incoming Webhook':

https://your-domain.slack.com/services/new/incoming-webhook

...this will get you a 'Webhook URL', which looks something like this:

https://hooks.slack.com/services/T05FTQF9H/B012N1Y2Y/p9VyRC1ZlTqNGuu

...stick that url into a GitHub webhook for your repo as the 'Payload URL':

https://github.com/my-org/my-repo/settings/hooks/new

...and then **disable** the hook in GitHub! You don't actually want to send _GitHub_ events to the hook - this is just a place to store the private url where Prout can find it. Note that prout needs repo-admin access in order to read the hook data!

This comes from @tackley's request for Ophan - he wants a way for users who don't have GitHub access to see features as they're released. Slack has a lower bar to entry for some of our users...

cc @tackley @philwills 