### PR TITLE
Mention the PR creator, as well as merger, if they are different people

### DIFF
--- a/app/lib/RepoSnapshot.scala
+++ b/app/lib/RepoSnapshot.scala
@@ -149,7 +149,10 @@ case class RepoSnapshot(
         Logger.trace(s"changedSnapshotsByState : ${snapshot.changedSnapshotsByState}")
 
         val timeSinceMerge = mergeToNow.toPeriod.withMillis(0).toString(pf)
-        val responsibleText = s"merged by ${pr.getMergedBy.atLogin} $timeSinceMerge ago"
+        val mergedByText = s"merged by ${pr.getMergedBy.atLogin} $timeSinceMerge ago"
+        val responsibleText = if (pr.getUser == pr.getMergedBy) mergedByText else {
+          s"created by ${pr.getUser.atLogin} and $mergedByText"
+        }
 
         def commentOn(status: PullRequestCheckpointStatus, advice: String) = {
           for (changedSnapshots <- snapshot.changedSnapshotsByState.get(status)) {


### PR DESCRIPTION
@rrees suggested this as being useful for teams where the developer and
the merger are typically different people (for instance, where the
merger is a gatekeeper QA) - you still want to let the developer know that
they need to check their stuff!

Many devs- overwhelmed by excess notifications, and perhaps unknowing
of the available controls in GitHub - have configured email filters
that immediately archive GitHub notifications - @mentioning them is
best chance of getting them to know that this is actually relevant to them.