### PR TITLE
Allow disabling SSL-verification so we can handle self-signed certs

### DIFF
--- a/app/lib/Config.scala
+++ b/app/lib/Config.scala
@@ -46,7 +46,9 @@ object Config {
     Json.fromJson[ConfigFile](fileJson)
   }
 
-  case class CheckpointDetails(url: Uri, overdue: Period)
+  case class CheckpointDetails(url: Uri, overdue: Period, disableSSLVerification: Option[Boolean] = None) {
+    val sslVerification = !disableSSLVerification.contains(true)
+  }
 
   object Checkpoint {
     implicit def checkpointToDetails(c: Checkpoint) = c.details

--- a/app/lib/SSL.scala
+++ b/app/lib/SSL.scala
@@ -1,0 +1,25 @@
+package lib
+
+import java.security.cert.X509Certificate
+import javax.net.ssl._
+
+import play.api.Logger
+
+object SSL {
+
+  val InsecureSocketFactory = {
+    val sslcontext = SSLContext.getInstance("TLS")
+    sslcontext.init(null, Array(TrustEveryoneTrustManager), null)
+    sslcontext.getSocketFactory
+  }
+
+  object TrustEveryoneTrustManager extends X509TrustManager {
+    def checkClientTrusted(chain: Array[X509Certificate], authType: String) {}
+
+    def checkServerTrusted(chain: Array[X509Certificate], authType: String) {
+      Logger.warn("Skipping SSL server chain verification")
+    }
+
+    val getAcceptedIssuers = new Array[X509Certificate](0)
+  }
+}

--- a/test/lib/ConfigSpec.scala
+++ b/test/lib/ConfigSpec.scala
@@ -1,0 +1,29 @@
+package lib
+
+import com.netaporter.uri.Uri
+import lib.Config.CheckpointDetails
+import org.joda.time.Period.minutes
+import org.scalatestplus.play._
+import play.api.libs.json.{JsResult, JsSuccess, Json}
+
+import scalax.io.JavaConverters._
+
+class ConfigSpec extends PlaySpec {
+
+   "Config json parsing" must {
+     "parse normal Checkpoint config" in {
+       val details = checkpointDetailsFrom("/sample.checkpoint.json")
+
+       details mustEqual JsSuccess(CheckpointDetails(Uri.parse("https://membership.theguardian.com/"), minutes(14)))
+       details.get.sslVerification mustBe true
+      }
+
+     "parse insecure config" in {
+       checkpointDetailsFrom("/sample.insecure.checkpoint.json").get.sslVerification mustBe false
+     }
+   }
+
+  def checkpointDetailsFrom(resourcePath: String): JsResult[CheckpointDetails] = {
+    Json.parse(getClass.getResource(resourcePath).asInput.byteArray).validate[CheckpointDetails]
+  }
+}

--- a/test/resources/sample.checkpoint.json
+++ b/test/resources/sample.checkpoint.json
@@ -1,0 +1,1 @@
+{ "url": "https://membership.theguardian.com/", "overdue": "14M" }

--- a/test/resources/sample.insecure.checkpoint.json
+++ b/test/resources/sample.insecure.checkpoint.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://workflow.release.dev-gutools.co.uk/management/healthcheck",
+  "overdue": "14M",
+  "disableSSLVerification": true
+}


### PR DESCRIPTION
Prout was failing for @chrisfinch on the Workflow project because their release environment uses a self-signed SSL certificate:

https://workflow.release.dev-gutools.co.uk/management/healthcheck

The new `"disableSSLVerification": true` option will enable Prout to hit this url without dying - cert verification will be turned off for that checkpoint:

```
{
    "checkpoints": {
        "RELEASE": { "url": "https://workflow.release.dev-gutools.co.uk/management/healthcheck", "overdue": "15M", "disableSSLVerification": true },
        "PROD": { "url": "https://workflow.gutools.co.uk/management/healthcheck", "overdue": "24H" }
    }
}
```
