### PR TITLE
Comment even on PR updates for oldish merges

### DIFF
--- a/app/lib/RepoSnapshot.scala
+++ b/app/lib/RepoSnapshot.scala
@@ -145,7 +145,8 @@ case class RepoSnapshot(
     override def actionTaker(snapshot: PullRequestCheckpointsSummary) {
       val pr = snapshot.pr
       val mergeToNow = new DateTime(pr.getMergedAt) to DateTime.now
-      if (mergeToNow.duration < WorthyOfCommentWindow) {
+      val previouslyTouchedByProut = snapshot.oldState.statusByCheckpoint.nonEmpty
+      if (previouslyTouchedByProut || mergeToNow.duration < WorthyOfCommentWindow) {
         Logger.trace(s"changedSnapshotsByState : ${snapshot.changedSnapshotsByState}")
 
         val timeSinceMerge = mergeToNow.toPeriod.withMillis(0).toString(pf)


### PR DESCRIPTION
The [WorthyOfCommentWindow](https://github.com/guardian/prout/blob/4557b388/app/lib/RepoSnapshot.scala#L43) (12 hours) is there to prevent a deluge of spam comments when you add Prout to a repo for the first time.

This tweaks that behaviour to **always** write a comment on the PR, so long as we've _previously_ set some label state on it (so shouldn't trigger a spam deluge on initial run).

Thanks to @sihil for mentioning that the behaviour seemed wrong :)

> On this PR PRout updated the label, but didn't write a message. Possible bug? > https://github.com/guardian/flexible-content/pull/1656
> 
> Also didn't send a message to #composer in slack AFAICS.
