### PR TITLE
Tolerate insecure hostnames when a checkpoint is 'insecure'

### DIFF
--- a/app/lib/CheckpointSnapshot.scala
+++ b/app/lib/CheckpointSnapshot.scala
@@ -16,6 +16,7 @@
 
 package lib
 
+import com.ning.http.util.AllowAllHostnameVerifier
 import com.squareup.okhttp.OkHttpClient
 import com.squareup.okhttp.Request.Builder
 import lib.Config.Checkpoint
@@ -31,7 +32,7 @@ import scala.concurrent._
 object CheckpointSnapshot {
 
   val client = new OkHttpClient()
-  val insecureClient = new OkHttpClient().setSslSocketFactory(InsecureSocketFactory)
+  val insecureClient = new OkHttpClient().setSslSocketFactory(InsecureSocketFactory).setHostnameVerifier(new AllowAllHostnameVerifier)
 
   val hexRegex = """\b\p{XDigit}{40}\b""".r
 


### PR DESCRIPTION
This follows on from https://github.com/guardian/prout/pull/16 - I hadn't realised I need to do more to get https://subscribe.theguardian.com.origin.membership.guardianapis.com working!

```
2015-04-24T13:22:06.531976+00:00 app[web.1]: play.api.Application$$anon$1: Execution exception[[SSLPeerUnverifiedException: Hostname subscribe.theguardian.com.origin.membership.guardianapis.com not verified:
2015-04-24T13:22:06.531978+00:00 app[web.1]:     certificate: sha1/mCMtEyeQDScszBArejIlux65p84=
2015-04-24T13:22:06.531979+00:00 app[web.1]:     DN: CN=subscribe.theguardian.com, OU=COMODO SSL, OU=Issued through Guardian News & Media Ltd E-PKI Manager, OU=Domain Control Validated
2015-04-24T13:22:06.531981+00:00 app[web.1]:     subjectAltNames: [subscribe.theguardian.com, www.subscribe.theguardian.com]]]
2015-04-24T13:22:06.531983+00:00 app[web.1]: 	at play.api.Application$class.handleError(Application.scala:296) ~[com.typesafe.play.play_2.11-2.3.8.jar:2.3.8]
2015-04-24T13:22:06.531984+00:00 app[web.1]: 	at play.api.DefaultApplication.handleError(Application.scala:402) [com.typesafe.play.play_2.11-2.3.8.jar:2.3.8]
2015-04-24T13:22:06.531986+00:00 app[web.1]: 	at play.core.server.netty.PlayDefaultUpstreamHandler$$anonfun$14$$anonfun$apply$1.applyOrElse(PlayDefaultUpstreamHandler.scala:205) [com.typesafe.play.play_2.11-2.3.8.jar:2.3.8]
2015-04-24T13:22:06.531988+00:00 app[web.1]: 	at play.core.server.netty.PlayDefaultUpstreamHandler$$anonfun$14$$anonfun$apply$1.applyOrElse(PlayDefaultUpstreamHandler.scala:202) [com.typesafe.play.play_2.11-2.3.8.jar:2.3.8]
2015-04-24T13:22:06.531991+00:00 app[web.1]: Caused by: javax.net.ssl.SSLPeerUnverifiedException: Hostname subscribe.theguardian.com.origin.membership.guardianapis.com not verified:
2015-04-24T13:22:06.531993+00:00 app[web.1]:     certificate: sha1/mCMtEyeQDScszBArejIlux65p84=
2015-04-24T13:22:06.531994+00:00 app[web.1]:     DN: CN=subscribe.theguardian.com, OU=COMODO SSL, OU=Issued through Guardian News & Media Ltd E-PKI Manager, OU=Domain Control Validated
2015-04-24T13:22:06.531996+00:00 app[web.1]:     subjectAltNames: [subscribe.theguardian.com, www.subscribe.theguardian.com]
2015-04-24T13:22:06.531997+00:00 app[web.1]: 	at com.squareup.okhttp.Connection.upgradeToTls(Connection.java:261) ~[com.squareup.okhttp.okhttp-2.3.0.jar:na]
2015-04-24T13:22:06.532002+00:00 app[web.1]: 	at com.squareup.okhttp.OkHttpClient$1.connectAndSetOwner(OkHttpClient.java:120) ~[com.squareup.okhttp.okhttp-2.3.0.jar:na]
2015-04-24T13:22:06.532003+00:00 app[web.1]: 	at com.squareup.okhttp.internal.http.HttpEngine.nextConnection(HttpEngine.java:330) ~[com.squareup.okhttp.okhttp-2.3.0.jar:na]
2015-04-24T13:22:06.531999+00:00 app[web.1]: 	at com.squareup.okhttp.Connection.connect(Connection.java:159) ~[com.squareup.okhttp.okhttp-2.3.0.jar:na]
2015-04-24T13:22:06.532000+00:00 app[web.1]: 	at com.squareup.okhttp.Connection.connectAndSetOwner(Connection.java:175) ~[com.squareup.okhttp.okhttp-2.3.0.jar:na]
```