### PR TITLE
Poll PRs even after they're overdue

### DIFF
--- a/app/lib/ScanScheduler.scala
+++ b/app/lib/ScanScheduler.scala
@@ -31,13 +31,13 @@ class ScanScheduler(repoFullName: RepoFullName,
         case Success(summaries) =>
           Logger.info(s"$selfScanScheduler : ${summaries.size} summaries for ${repoFullName.text}:\n${summaries.map(s => s"#${s.pr.getNumber} ${s.stateChange}").mkString("\n")}")
 
-          val scanTimeForPendingOpt = summaries.find(_.hasPendingCheckpoints).map(_ => Instant.now + 1.minute)
+          val scanTimeForUnseenOpt = summaries.find(!_.checkpointStatuses.all(Seen)).map(_ => Instant.now + 1.minute)
 
           val overdueTimes = summaries.collect {
             case summary => summary.soonestPendingCheckpointOverdueTime
           }.flatten
 
-          val candidateFollowUpScanTimes = overdueTimes ++ scanTimeForPendingOpt
+          val candidateFollowUpScanTimes = overdueTimes ++ scanTimeForUnseenOpt
 
           if (candidateFollowUpScanTimes.nonEmpty) {
             val earliestCandidateScanTime: Instant = candidateFollowUpScanTimes.min


### PR DESCRIPTION
Users found it understandably confusing that Prout wasn't polling PRs after they were overdue:

https://github.com/guardian/membership-frontend/pull/538#issuecomment-103893650

Note that for guardian/membership-frontend, the post-deploy hook from RiffRaff hits Prout after the deploy 'completes', but I think sometimes the site is still serving old content (due to caching and Fastly) a little bit longer. When Prout scanned the site after the deploy, it still had the old commit (guardian/membership-frontend@b43457b7):

```
2015-05-20T13:46:05.746475+00:00 app[web.1]: [ESC[37minfoESC[0m] application - guardian/membership-frontend has 1 active snapshots : Map(PROD -> b43457b7)
```
https://riffraff.gutools.co.uk/deployment/view/9276b501-68a4-491c-9a18-844fa73289c4#
```
[14:45:58] task ResumeAlarmNotifications Resuming Alarm Notifications - group will scale on any configured alarms
```
We have a cache time of 1 minute on the front page, so it's not too surprising that it would be serving the old version of the site - RiffRaff just feels that the deploy is done, because the ASG/ELB have stabilised, but we have a slightly different definition :-)

cc @philwills @davidrapson