### PR TITLE
Don't attempt to scan repos that don't contain `.prout.json` files

### DIFF
--- a/app/controllers/RepoWhitelistService.scala
+++ b/app/controllers/RepoWhitelistService.scala
@@ -1,8 +1,9 @@
 package controllers
 
 import akka.agent.Agent
+import com.typesafe.scalalogging.LazyLogging
+import lib.ConfigFinder.ProutConfigFileName
 import lib.{Bot, RepoFullName}
-import org.kohsuke.github.GHRepository
 import play.api.Logger
 import play.api.Play.current
 import play.api.libs.concurrent.Akka
@@ -14,7 +15,7 @@ import scala.concurrent.duration._
 
 case class RepoWhitelist(allKnownRepos: Set[RepoFullName], publicRepos: Set[RepoFullName])
 
-object RepoWhitelistService {
+object RepoWhitelistService extends LazyLogging {
   lazy val repoWhitelist = Agent[RepoWhitelist](RepoWhitelist(Set.empty, Set.empty))
 
   def whitelist(): Future[RepoWhitelist] = repoWhitelist.future()
@@ -23,12 +24,22 @@ object RepoWhitelistService {
 
   private def getAllKnownRepos = {
     val gitHub = Bot.githubCredentials.conn()
-    val allRepos = gitHub.getMyself.listRepositories().filter(_.hasPushAccess).toSet
+    val allReposWithPushAccess = gitHub.getMyself.listRepositories().filter(_.hasPushAccess).toSet
+
+    logger.info(s"Starting allReposWithPushAccess (${allReposWithPushAccess.size}) filter")
+    val allRepos = allReposWithPushAccess.par.filter {
+      r =>
+        val defaultBranchSha = r.getRef(s"heads/${r.getDefaultBranch}").getObject.getSha
+        val treeRecursive = r.getTreeRecursive(defaultBranchSha, 1)
+        if (treeRecursive.isTruncated) logger.error("Truncated tree for "+r.getFullName)
+        treeRecursive.getTree.exists(_.getPath.endsWith(ProutConfigFileName))
+    }.seq
+
+    logger.warn(s"allRepos size = ${allRepos.size}")
+
     val publicRepos = allRepos.filterNot(_.isPrivate)
 
-    val wl = RepoWhitelist(allRepos.map(RepoFullName(_)), publicRepos.map(RepoFullName(_)))
-    Logger.trace(s"wl=$wl")
-    wl
+    RepoWhitelist(allRepos.map(RepoFullName(_)), publicRepos.map(RepoFullName(_)))
   }
 
   def start() {

--- a/app/lib/ConfigFinder.scala
+++ b/app/lib/ConfigFinder.scala
@@ -8,8 +8,12 @@ import org.eclipse.jgit.treewalk.TreeWalk
 import play.api.libs.json.JsResult
 
 object ConfigFinder {
-
-  private val configFilter: TreeWalk => Boolean = w => w.isSubtree || w.getNameString == ".prout.json"
+  
+  val ProutConfigFileName = ".prout.json"
+  
+  private val configFilter: TreeWalk => Boolean = w => {
+    w.isSubtree || w.getNameString == ProutConfigFileName
+  }
 
   /**
    *


### PR DESCRIPTION
Cloning a repo just to find out if it contains a .prout.json file can be pretty CPU & network intensive - for instance when it's a big repo like https://github.com/guardian/frontend . Fortunately the GitHub API has an endpoint which can give a full file list of paths in a given commit's tree:

https://developer.github.com/v3/git/trees/#get-a-tree-recursively

I was concerned about the truncation of the returned tree - thanks to @izuzak of GitHub Support for indicating that it's unlikely that we'll encounter this behaviour.

Doing this filtering gives a 90% reduction in the number of repos we attempt to scan for our Guardian installation of Prout - where team permissions can sometimes get a little... caca.