### PR TITLE
Test feedback screencast

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -100,7 +100,7 @@ object Api extends Controller {
 
   def travisHook() = Action(parse.json) { implicit r =>
     Logger.info("Travis hook triggered.")
-    implicit val personReads = Json.reads[TravisTestResult]
+    implicit val travisTestResultReads = Json.reads[TravisTestResult]
     val result = r.body.as[TravisTestResult]
     Logger.info(s"Travis test result data: ${result}}")
 

--- a/app/lib/TestFeedback.scala
+++ b/app/lib/TestFeedback.scala
@@ -33,11 +33,23 @@ object TestFeedback {
     val detailsLink =
       s"[Details](https://travis-ci.org/${r.repoSlug}/builds/${r.buildId})"
 
-    val screencastLink = s"[Screencast](https://saucelabs.com/tests/${r.remoteWebDriverSessionId})"
+    val screencastLink = s"[Screencast](https://saucelabs.com/tests/${r.screencastId})"
+
+    val testsPassedMsg =
+      s"""
+        | :white_check_mark: Post-deployment testing passed! | ${screencastLink} | ${detailsLink}
+        | -------------------------------------------------- | ----------------- | --------------
+      """.stripMargin
+
+    val testsFailedMsg =
+      s"""
+         | :x: Post-deployment testing failed! | ${screencastLink} | ${detailsLink}
+         | ----------------------------------- | ----------------- | --------------
+      """.stripMargin
 
     r.testResult match {
-      case "0" => s":clap: Post-deployment testing passed! ${detailsLink} ${screencastLink}"
-      case _ => s":cry: Post-deployment testing failed! ${detailsLink} ${screencastLink}"
+      case "0" => testsPassedMsg
+      case _ => testsFailedMsg
     }
   }
 
@@ -51,7 +63,8 @@ object TestFeedback {
  * @param commit SHA
  * @param testResult build result
  * @param buildId build ID
+ * @param screencastId Remote Web Driver session ID
  */
 case class TravisTestResult(repoSlug: String, commit: String,
                             testResult: String, buildId: String,
-                            remoteWebDriverSessionId: String)
+                            screencastId: String)

--- a/app/lib/TestFeedback.scala
+++ b/app/lib/TestFeedback.scala
@@ -33,9 +33,11 @@ object TestFeedback {
     val detailsLink =
       s"[Details](https://travis-ci.org/${r.repoSlug}/builds/${r.buildId})"
 
+    val screencastLink = s"[Screencast](https://saucelabs.com/tests/${r.remoteWebDriverSessionId})"
+
     r.testResult match {
-      case "0" => s":clap: Post-deployment testing passed! ${detailsLink}"
-      case _ => s":cry: Post-deployment testing failed! ${detailsLink}"
+      case "0" => s":clap: Post-deployment testing passed! ${detailsLink} ${screencastLink}"
+      case _ => s":cry: Post-deployment testing failed! ${detailsLink} ${screencastLink}"
     }
   }
 
@@ -51,4 +53,5 @@ object TestFeedback {
  * @param buildId build ID
  */
 case class TravisTestResult(repoSlug: String, commit: String,
-                            testResult: String, buildId: String)
+                            testResult: String, buildId: String,
+                            remoteWebDriverSessionId: String)

--- a/test/resources/sample.test_feedback.sh
+++ b/test/resources/sample.test_feedback.sh
@@ -3,7 +3,7 @@
 # =============================================================================
 # Reports to Prout the result of post-deployment test executed by Travis build.
 #
-# Establishes a webhook into Prout from Travis CI.
+# Sends POST request to Prout's Tavis webhook.
 # Specified to be called by after_script field in .prout.json
 #
 # References:
@@ -16,11 +16,18 @@ echo "Feeding test results back to Prout..."
 # Display expanded commands
 set -ex
 
-# Prout API endpoint
+# Prout's Travis webhook
 PROUT_HOOK=https://my-prout-host/api/hooks/travis
 
+# SauceLabs session ID
+if [ ! -f ./logs/screencastId ]; then
+    SCREENCAST_ID=""
+else
+    SCREENCAST_ID=`cat ./logs/screencastId`
+fi
+
 # Json representing testing-in-production results
-TEST_RESULT="{\"repoSlug\":\"$TRAVIS_REPO_SLUG\",\"commit\":\"$TRAVIS_COMMIT\",\"testResult\":\"$TRAVIS_TEST_RESULT\",\"buildId\":\"$TRAVIS_BUILD_ID\"}"
+TEST_RESULT="{\"repoSlug\":\"$TRAVIS_REPO_SLUG\",\"commit\":\"$TRAVIS_COMMIT\",\"testResult\":\"$TRAVIS_TEST_RESULT\",\"buildId\":\"$TRAVIS_BUILD_ID\",\"screencastId\":\"$SCREENCAST_ID\"}"
 
 # POST test results to Prout
 curl -X POST -H "Content-Type: application/json" -d $TEST_RESULT $PROUT_HOOK


### PR DESCRIPTION
@rtyley 

Add screencast link to test result comment, which takes you directly to the relevant Sauce Labs screencast.

Examples of how it looks:
* [Post-deployment testing passed](https://github.com/mario-galic/sandbox/pull/77)
* [Post-deployment testing failed](https://github.com/mario-galic/sandbox/pull/65)

*Note this PR is based on [test-feedback](https://github.com/guardian/prout/pull/27) branch.*