### PR TITLE
Add test feedback labels

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -104,7 +104,7 @@ object Api extends Controller {
     val result = r.body.as[TravisTestResult]
     Logger.info(s"Travis test result data: ${result}}")
 
-    val comment = TestFeedback.notify(result)
+    val comment = TestFeedback(result).notifyGitHub
     Ok(comment.getBody)
   }
 }

--- a/app/lib/PullRequestCheckpointTestStatus.scala
+++ b/app/lib/PullRequestCheckpointTestStatus.scala
@@ -1,0 +1,29 @@
+package lib
+
+import lib.Config.Checkpoint
+
+sealed trait PullRequestCheckpointTestStatus {
+
+  val name = getClass.getSimpleName.dropRight(1)
+
+  def labelFor(checkpointName: String) = {
+    name + "-in-" + checkpointName
+  }
+
+  val defaultColour: String
+}
+
+object PullRequestCheckpointTestStatus {
+  val all = Set[PullRequestCheckpointTestStatus](Pass, Fail)
+
+  def fromLabels(labels: Set[String], checkpoint: Checkpoint): Option[PullRequestCheckpointTestStatus] =
+    PullRequestCheckpointTestStatus.all.find(s => labels(s.labelFor(checkpoint.name)))
+}
+
+case object Pass extends PullRequestCheckpointTestStatus {
+  override val defaultColour: String = "bfe5bf"
+}
+
+case object Fail extends PullRequestCheckpointTestStatus {
+  override val defaultColour: String = "e11d21"
+}


### PR DESCRIPTION
@rtyley 

Examples of post-deployment test result labels being set:

* [Pass label](https://github.com/mario-galic/sandbox/pull/83)
* [Fail label](https://github.com/mario-galic/sandbox/pull/84)

This currently works only if there is a single checkpoint defined in `.prout.json`

*Note this PR is based on [test-feedback](https://github.com/guardian/prout/pull/27) branch.*
