### PR TITLE
Rebase test feedback endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Prout
 
+## "Has your pull request been deployed yet?"
+
 _"Has your pull request been deployed yet?"_ - [Guardian blogpost](http://www.theguardian.com/info/developer-blog/2015/feb/03/prout-is-your-pull-request-out)
 
 Tells you when your pull-requests are live. Tells you when they're not, and should be.
@@ -25,8 +27,18 @@ forget about promptly reviewing their changes on Production.
 Prout simply notifies developers in their pull request that the code has been _seen_
 in Production (a slightly stronger statement than simply saying it's been deployed).
 
+## "Have post-deployment tests passed?"
 
-# Configuration
+![prout pass-in-prod](https://cloud.githubusercontent.com/assets/13835317/12692343/a51ff6bc-c6ed-11e5-8366-eb9470e0bab1.png)
+
+Prout can facilitate _testing-in-production_ workflow by notifying developers 
+of the result of post-deployment tests that have run against production 
+(or any stage you deployed to). The result is posted as a comment on the pull request's
+conversation thread. 
+
+(Currently this feature works only with Travis CI).
+
+# Configuration <a name="config"></a>
 
 Follow the 4-step program:
 
@@ -34,6 +46,9 @@ Follow the 4-step program:
 2. Add one or more .prout.json config files to your project
 3. Add callbacks to prout - ie a GitHub webhook and ideally also a post-deploy hook
 4. Expose the commit id of your build on your deployed site
+
+For post-deployment testing configuration see [bellow](#test-config).
+
 
 ### Add config file
 
@@ -120,6 +135,26 @@ https://github.com/my-org/my-repo/settings/hooks/new
 events to the hook - this is just a place to store the private url where Prout can find it.
 **Note that Prout needs repo-admin access in order to read the hook data!**
 
+# Post-deployment testing
+
+After the pull request has been closed, merged, deployed and seen, Prout can trigger a Travis CI
+build that executes post-deployment tests. When the test build completes, Travis
+feeds back the result to Prout, which in turn posts the result on the pull request as a comment.
+
+## Configuration <a name="test-config"></a>
+
+1. Complete all the steps [above](#config). 
+2. Next add Travis configuration to `.prout.json`: see [sample](./test/resources/sample.test_feedback.json).    
+3. Note that `afterSeen` uses [Travis build customization](http://docs.travis-ci.com/user/customizing-the-build/)
+specification.
+4. Add `test_feedback.sh` (see [sample](./test/resources/sample.test_feedback.sh)) script under 
+the project root directory.
+5. Set its permissions to: `chmod ugo+x test_feedback.sh`
+6. Adjust `PROUT_HOOK` to target your Prout host.
+
+This script is triggered after the build completes. It collects relevant test result data
+from [Travis environmental variables](http://docs.travis-ci.com/user/environment-variables/)
+and feeds it back to Prout via `/api/hooks/travis` endpoint.
 
 # Run your own instance of Prout
 

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -22,7 +22,7 @@ import lib.actions.Parsers.parseGitHubHookJson
 import play.api.Logger
 import play.api.Play.current
 import play.api.cache.Cache
-import play.api.libs.json.{JsArray, JsNumber}
+import play.api.libs.json.{JsArray, JsNumber, Json}
 import play.api.mvc._
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -93,5 +93,12 @@ object Api extends Controller {
         scan <- scanGuard
       } yield Ok(JsArray(scan.map(summary => JsNumber(summary.prCheckpointDetails.pr.number))))
     }
+  }
+
+  def travisHook() = Action.async(parse.json) { implicit r =>
+    implicit val travisTestResultReads = Json.reads[TravisTestResult]
+    val result = r.body.as[TravisTestResult]
+    Logger.info(s"travisHook ${result}")
+    TestFeedback(result).notifyGitHub()
   }
 }

--- a/app/lib/RepoSnapshot.scala
+++ b/app/lib/RepoSnapshot.scala
@@ -31,7 +31,7 @@ import com.typesafe.scalalogging.LazyLogging
 import lib.Config.Checkpoint
 import lib.RepoSnapshot._
 import lib.gitgithub.{IssueUpdater, LabelMapping}
-import lib.labels.{Overdue, PullRequestCheckpointStatus, Seen}
+import lib.labels.{Overdue, PullRequestCheckpointStatus, PullRequestCheckpointTestStatus, Seen}
 import lib.travis.TravisApiClient
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.revwalk.{RevCommit, RevWalk}
@@ -263,7 +263,7 @@ case class RepoSnapshot(
   } yield summaryOpts.flatten
 
   def missingLabelsGiven(existingLabelNames: Set[String]): Set[CreateLabel] = for {
-    prcs <- PullRequestCheckpointStatus.all
+    prcs <- (PullRequestCheckpointStatus.all ++ PullRequestCheckpointTestStatus.all)
     checkpointName <- config.checkpointsByName.keySet
     label = prcs.labelFor(checkpointName)
     if !existingLabelNames(label)

--- a/app/lib/TestFeedback.scala
+++ b/app/lib/TestFeedback.scala
@@ -1,0 +1,161 @@
+package lib
+
+import com.madgag.git._
+import com.madgag.scalagithub.GitHub._
+import com.madgag.scalagithub.commands.CreateComment
+import com.madgag.scalagithub.model._
+import lib.RepoSnapshot.mergedPullRequestsFor
+import lib.labels.{Fail, Pass, Seen}
+import org.eclipse.jgit.revwalk.{RevCommit, RevWalk}
+import play.api.Logger
+import play.api.libs.json._
+import play.api.mvc.Result
+import play.api.mvc.Results.Ok
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent._
+import scala.concurrent.duration._
+import scalax.file.ImplicitConversions._
+import scalax.file.Path
+
+case class TestFeedback(r: TravisTestResult) {
+
+  /** Post a comment and set labels of post-deployment Travis CI test result
+    * on the last released PR. */
+  def notifyGitHub(): Future[Result] = {
+    for {
+      pr <- latestReleasedPullRequestF
+      comment <- postTestResultComment(pr)
+      labelsF <- setTestResultLabels(pr)
+      label <- labelsF
+    } yield {
+      Logger.info(
+        s"Test result posted on PR:  ${pr.number}, ${pr.title}, ${pr.merged_at}")
+
+      val resultJson = Json.parse(s"""
+      {
+        "pr_num" : "${pr.number}",
+        "test_result" : "${r.testResult}"
+      }
+      """)
+
+      Ok(resultJson)
+    }
+  }
+
+  private implicit val github = Bot.github
+
+  private val githubRepo =
+    Await.result(github.getRepo(RepoId.from(r.repoSlug)), 30.seconds)
+
+  // Released PR = closed + merged + seen
+  private def latestReleasedPullRequestF: Future[PullRequest] = {
+
+    def isSeen(pr: PullRequest): Future[Boolean] = {
+      for {
+        labels <- pr.labels.list().all()
+      } yield {
+        labels.exists(l => l.name == Seen.labelFor(checkpoint)) // i.e., has Seen-on-PROD label
+      }
+    }
+
+    // merged_at is always defined for merged PRs, so it is ok to call 'get' on an Option here
+    implicit def timeOfMergeDescendingOrdering: Ordering[PullRequest] =
+      Ordering.fromLessThan(_.merged_at.get isAfter _.merged_at.get)
+
+    for {
+      mergedPRs <- mergedPullRequestsFor(githubRepo)
+      seenPRs <- Future.traverse(mergedPRs){ pr => isSeen(pr).map(b => pr -> b) }.map(_.collect{ case (pr, true) => pr })
+    } yield {
+      seenPRs.sorted.head // last released PR
+    }
+  }
+
+  private def postTestResultComment(pr: PullRequest) =
+    pr.comments2.create(CreateComment(s"$resultComment"))
+
+  private def setTestResultLabels(pr: PullRequest) = {
+
+    for {
+      labels <- pr.labels.list().all()
+    } yield {
+
+      val currentLabels = labels.map(_.name)
+
+      val updatedLabels = r.testResult match {
+        case "0" => { // test passed
+          val allLabelsButFail = currentLabels.filterNot(l => l == Fail.labelFor(checkpoint))
+          allLabelsButFail :+ Pass.labelFor(checkpoint)
+        }
+        case _ => { // test failed
+          val allLabelsButPass = currentLabels.filterNot(l => l == Pass.labelFor(checkpoint))
+          allLabelsButPass :+ Fail.labelFor(checkpoint)
+        }
+      }
+
+      pr.labels.replace(updatedLabels)
+    }
+
+  }
+
+  /* Builds either failure or success comment */
+  private def resultComment: String = {
+    val detailsLink =
+      s"[Details](https://travis-ci.org/${r.repoSlug}/builds/${r.buildId})"
+
+    val screencastLink = s"[Screencast](https://saucelabs.com/tests/${r.screencastId})"
+
+    val testsPassedMsg =
+      s"""
+        | :white_check_mark: Post-deployment testing passed! | ${screencastLink} | ${detailsLink}
+        | -------------------------------------------------- | ----------------- | --------------
+      """.stripMargin
+
+    val testsFailedMsg =
+      s"""
+         | :x: Post-deployment testing failed! | ${screencastLink} | ${detailsLink}
+         | ----------------------------------- | ----------------- | --------------
+      """.stripMargin
+
+    r.testResult match {
+      case "0" => testsPassedMsg
+      case _ => testsFailedMsg
+    }
+  }
+
+
+  /* Checkpoint (stage) from .prout.json */
+  private def checkpoint: String = {
+
+    val gitRepo = RepoUtil.getGitRepo(
+      Bot.parentWorkDir / Path.fromString(r.repoSlug),
+      githubRepo.clone_url,
+      Some(Bot.githubCredentials.git))
+
+    implicit val repoThreadLocal = gitRepo.getObjectDatabase.threadLocalResources
+
+    lazy val masterCommit:RevCommit =
+      gitRepo.resolve(githubRepo.default_branch).asRevCommit(new RevWalk(repoThreadLocal.reader()))
+
+
+    lazy val config = ConfigFinder.config(masterCommit)
+
+    config.checkpointsByName.keySet.head
+  }
+}
+
+/**
+ * Post-deployment test result data from Travis CI
+ *
+ * @param repoSlug owner/repo
+ * @param commit SHA
+ * @param testResult build result
+ * @param buildId build ID
+ * @param screencastId Remote Web Driver session ID
+ */
+case class TravisTestResult(
+    repoSlug: String,
+    commit: String,
+    testResult: String,
+    buildId: String,
+    screencastId: String)

--- a/app/lib/labels/PullRequestCheckpointTestStatus.scala
+++ b/app/lib/labels/PullRequestCheckpointTestStatus.scala
@@ -1,0 +1,24 @@
+package lib.labels
+
+import lib.Config.Checkpoint
+
+sealed trait PullRequestCheckpointTestStatus extends PullRequestLabel {
+  def labelFor(checkpointName: String) = {
+    name + "-in-" + checkpointName
+  }
+}
+
+object PullRequestCheckpointTestStatus {
+  val all = Set[PullRequestCheckpointTestStatus](Pass, Fail)
+
+  def fromLabels(labels: Set[String], checkpoint: Checkpoint): Option[PullRequestCheckpointTestStatus] =
+    PullRequestCheckpointTestStatus.all.find(s => labels(s.labelFor(checkpoint.name)))
+}
+
+case object Pass extends PullRequestCheckpointTestStatus {
+  override val defaultColour: String = "bfe5bf"
+}
+
+case object Fail extends PullRequestCheckpointTestStatus {
+  override val defaultColour: String = "e11d21"
+}

--- a/conf/routes
+++ b/conf/routes
@@ -4,10 +4,7 @@ POST        /api/update/$repo<[^/]+/[^/]+>  controllers.Api.updateRepo(repo: Rep
 # GET because that's what RiffRaff supports...
 GET         /api/update/$repo<[^/]+/[^/]+>  controllers.Api.updateRepo(repo: RepoId)
 POST        /api/hooks/github               controllers.Api.githubHook()
-
-
-
-
+POST        /api/hooks/travis             controllers.Api.travisHook()
 
 
 ### Non-API endpoints - resources for humans to view

--- a/test/resources/sample.test_feedback.json
+++ b/test/resources/sample.test_feedback.json
@@ -1,0 +1,16 @@
+{
+  "checkpoints": {
+    "PROD": {
+      "url": "https://mysite.com/",
+      "overdue": "3M",
+      "afterSeen": {
+        "travis": {
+          "config": {
+            "script": "sbt test",
+            "after_script": "./sample.test_feedback.sh"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/resources/sample.test_feedback.sh
+++ b/test/resources/sample.test_feedback.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# =============================================================================
+# Reports to Prout the result of post-deployment test executed by Travis build.
+#
+# Sends POST request to Prout's Tavis webhook.
+# Specified to be called by after_script field in .prout.json
+#
+# References:
+#   - http://docs.travis-ci.com/user/customizing-the-build/
+#   - http://docs.travis-ci.com/user/environment-variables/
+# =============================================================================
+echo "Feeding test results back to Prout..."
+
+# Exit as soon as one command returns a non-zero exit code.
+# Display expanded commands
+set -ex
+
+# Prout's Travis webhook
+PROUT_HOOK=https://my-prout-host/api/hooks/travis
+
+# SauceLabs session ID
+if [ ! -f ./logs/screencastId ]; then
+    SCREENCAST_ID=""
+else
+    SCREENCAST_ID=`cat ./logs/screencastId`
+fi
+
+# Json representing testing-in-production results
+TEST_RESULT="{\"repoSlug\":\"$TRAVIS_REPO_SLUG\",\"commit\":\"$TRAVIS_COMMIT\",\"testResult\":\"$TRAVIS_TEST_RESULT\",\"buildId\":\"$TRAVIS_BUILD_ID\",\"screencastId\":\"$SCREENCAST_ID\"}"
+
+# POST test results to Prout
+curl -X POST -H "Content-Type: application/json" -d $TEST_RESULT $PROUT_HOOK


### PR DESCRIPTION
@rtyley

[Example](https://github.com/mario-galic/sandbox/pull/98) 

Rebased test-feedback branch after Roberto's refactoring to use solely scalagithub.

The old test-feedback branch https://github.com/guardian/prout/pull/27 should be closed without merging.
