### PR TITLE
Remove Some(...) from slack message

### DIFF
--- a/app/lib/slack/DeployReporter.scala
+++ b/app/lib/slack/DeployReporter.scala
@@ -29,7 +29,7 @@ object DeployReporter {
         val checkpointsAsSlack = checkpoints.map(c => s"<${c.details.url}|${c.name}>").mkString(", ")
         val json = Json.toJson(
           Message(
-            s"*Deployed to $checkpointsAsSlack: ${pr.title}*\n\n${pr.body}",
+            s"*Deployed to $checkpointsAsSlack: ${pr.title}*\n\n${pr.body.getOrElse("")}",
             Some(lib.Bot.user.login),
             Some(mergedBy.avatar_url),
             attachments

--- a/app/lib/slack/DeployReporter.scala
+++ b/app/lib/slack/DeployReporter.scala
@@ -21,15 +21,15 @@ object DeployReporter {
         val checkpoints = changedSnapshots.map(_.snapshot.checkpoint)
         val attachments = Seq(Attachment(s"PR #${pr.number} deployed to ${checkpoints.map(_.name).mkString(", ")}",
           Seq(
-            Attachment.Field("PR", s"<${pr.html_url}|#${pr.number}>", true),
-            Attachment.Field("Merged by", s"<${mergedBy.html_url}|${mergedBy.atLogin}>", true)
+            Attachment.Field("PR", s"<${pr.html_url}|#${pr.number}>", short = true),
+            Attachment.Field("Merged by", s"<${mergedBy.html_url}|${mergedBy.atLogin}>", short = true)
           )
         ))
 
         val checkpointsAsSlack = checkpoints.map(c => s"<${c.details.url}|${c.name}>").mkString(", ")
         val json = Json.toJson(
           Message(
-            s"*Deployed to $checkpointsAsSlack: ${pr.title}*\n\n${pr.body.getOrElse("")}",
+            s"*Deployed to $checkpointsAsSlack: ${pr.title}*\n\n${pr.body.mkString}",
             Some(lib.Bot.user.login),
             Some(mergedBy.avatar_url),
             attachments


### PR DESCRIPTION
The message posted to slack looked like this:

<img width="594" alt="screen shot 2016-08-14 at 23 09 55" src="https://cloud.githubusercontent.com/assets/51444/17652509/0e47e1e4-6276-11e6-9f7f-c94dbd8847c2.png">

And that Some(...) was really annoying me. This change fixes, tested successfully on our prout instance.