### PR TITLE
Fixes #17 - unwanted removal of unassociated PR labels

### DIFF
--- a/app/lib/RepoSnapshot.scala
+++ b/app/lib/RepoSnapshot.scala
@@ -151,6 +151,11 @@ case class RepoSnapshot(
 
   val allAvailableCheckpoints: Set[Checkpoint] = config.checkpointsByName.values.toSet
 
+  val allPossibleCheckpointPRLabels: Set[String] = for {
+    prLabel <- PullRequestLabel.all
+    checkpoint <- allAvailableCheckpoints
+  } yield prLabel.labelFor(checkpoint.name)
+
   def diagnostic(): Future[Diagnostic] = {
     for {
       snapshots <- snapshotOfAllAvailableCheckpoints()
@@ -185,6 +190,8 @@ case class RepoSnapshot(
 
   val issueUpdater = new IssueUpdater[PullRequest, PRCheckpointState, PullRequestCheckpointsStateChangeSummary] with LazyLogging {
     val repo = self.repo
+
+    val repoSnapshot: RepoSnapshot = self
 
     val pf=PeriodFormat.getDefault
 

--- a/app/lib/gitgithub/IssueUpdater.scala
+++ b/app/lib/gitgithub/IssueUpdater.scala
@@ -2,7 +2,7 @@ package lib.gitgithub
 
 import com.madgag.scalagithub.GitHub._
 import com.madgag.scalagithub.model.{PullRequest, Repo}
-import lib.{Bot, Delayer, LabelledState}
+import lib.{Bot, Delayer, LabelledState, RepoSnapshot}
 import play.api.Logger
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -24,6 +24,8 @@ trait IssueUpdater[IssueType <: PullRequest, PersistableState, Snapshot <: State
 
   val repo: Repo
 
+  val repoSnapshot: RepoSnapshot
+
   val labelToStateMapping:LabelMapping[PersistableState]
 
   def ignoreItemsWithExistingState(existingState: PersistableState): Boolean
@@ -35,7 +37,7 @@ trait IssueUpdater[IssueType <: PullRequest, PersistableState, Snapshot <: State
   def process(issueLike: IssueType): Future[Option[Snapshot]] = {
     logger.trace(s"handling ${issueLike.prId.slug}")
     for {
-      oldLabels <- new LabelledState(issueLike, _ => true).currentLabelsF
+      oldLabels <- new LabelledState(issueLike, repoSnapshot.allPossibleCheckpointPRLabels).currentLabelsF
       snapshot <- takeSnapshotOf(issueLike, oldLabels)
     } yield snapshot
   }

--- a/app/lib/labels/PullRequestLabel.scala
+++ b/app/lib/labels/PullRequestLabel.scala
@@ -7,3 +7,7 @@ trait PullRequestLabel {
 
   val defaultColour: String
 }
+
+object PullRequestLabel {
+  val all: Set[PullRequestLabel] = PullRequestCheckpointStatus.all ++ CheckpointTestStatus.all
+}


### PR DESCRIPTION
Fixes  https://github.com/guardian/prout/issues/17 - the key is to create a list of every label that we might produce - anything else should be left unaffected.

cc @TBonnin



