### PR TITLE
Increase number of PRs scanned per repo to cope with Frontend pace of dev

### DIFF
--- a/app/lib/RepoSnapshot.scala
+++ b/app/lib/RepoSnapshot.scala
@@ -50,6 +50,8 @@ object RepoSnapshot {
 
   val logger = Logger(getClass)
 
+  val MaxPRsToScanPerRepo = 30
+
   val WorthyOfScanWindow: java.time.Duration = 14.days
 
   val WorthyOfCommentWindow: java.time.Duration = 12.hours
@@ -74,7 +76,7 @@ object RepoSnapshot {
     implicit val r = repo
     (for {
       litePullRequests <- repo.pullRequests.list(ClosedPRsMostlyRecentlyUpdated).takeUpTo(2)
-      pullRequests <- Future.traverse(litePullRequests.filter(isMergedToMaster).filter(isNewEnoughToBeWorthScanning).take(30))(pr => repo.pullRequests.get(pr.number).map(_.result))
+      pullRequests <- Future.traverse(litePullRequests.filter(isMergedToMaster).filter(isNewEnoughToBeWorthScanning).take(MaxPRsToScanPerRepo))(pr => repo.pullRequests.get(pr.number).map(_.result))
     } yield {
       log(s"PRs merged to master size=${pullRequests.size}")
       pullRequests

--- a/app/lib/RepoSnapshot.scala
+++ b/app/lib/RepoSnapshot.scala
@@ -17,6 +17,7 @@
 package lib
 
 import java.time.Instant.now
+import java.time.ZonedDateTime
 
 import com.madgag.git._
 import com.madgag.github.Implicits._
@@ -49,6 +50,8 @@ object RepoSnapshot {
 
   val logger = Logger(getClass)
 
+  val WorthyOfScanWindow: java.time.Duration = 14.days
+
   val WorthyOfCommentWindow: java.time.Duration = 12.hours
 
   val travisApiClient = new TravisApiClient(Bot.accessToken)
@@ -64,10 +67,14 @@ object RepoSnapshot {
   def isMergedToMaster(pr: PullRequest)(implicit repo: Repo): Boolean = pr.merged_at.isDefined && pr.base.ref == repo.default_branch
 
   def mergedPullRequestsFor(repo: Repo)(implicit g: GitHub): Future[Seq[PullRequest]] = {
+    val now = ZonedDateTime.now()
+    val timeThresholdForScan = now.minus(WorthyOfScanWindow)
+    def isNewEnoughToBeWorthScanning(pr: PullRequest) = pr.merged_at.exists(_.isAfter(timeThresholdForScan))
+
     implicit val r = repo
     (for {
       litePullRequests <- repo.pullRequests.list(ClosedPRsMostlyRecentlyUpdated).takeUpTo(2)
-      pullRequests <- Future.traverse(litePullRequests.filter(isMergedToMaster).take(10))(pr => repo.pullRequests.get(pr.number).map(_.result))
+      pullRequests <- Future.traverse(litePullRequests.filter(isMergedToMaster).filter(isNewEnoughToBeWorthScanning).take(30))(pr => repo.pullRequests.get(pr.number).map(_.result))
     } yield {
       log(s"PRs merged to master size=${pullRequests.size}")
       pullRequests


### PR DESCRIPTION
These PRs by @katebee were not fully updated by Prout:

* https://github.com/guardian/frontend/pull/15460
* https://github.com/guardian/frontend/pull/15465

The PRs were marked as 'Pending' but not 'Seen', because Prout was only examining the 10 most-recently updated PRs (note that the only available sort options are `created`, `updated`, `comments` - https://developer.github.com/v3/issues/ ) - it does this to avoid burning through GitHub API quota too quickly. On Frontend, the pace of development is such that by the time @katebee's PRs had been deployed, more than 10 other PRs had been merged or commented-on - so Prout never scanned or updated Kate's PRs from that point onward.

This change now looks at the 30 most recently updated PRs, of the PRs that have been updated in the last 14 days. This means that for very busy repos like guardian/frontend it _will_ consume more GitHub API quota, but for repos that change less frequently, we still won't be expending quota on 'old' PRs.

Hopefully we won't bust the 5000 per hour quota limit!

cc @TBonnin