### PR TITLE
Remove PR body from Slack message

### DIFF
--- a/app/lib/slack/DeployReporter.scala
+++ b/app/lib/slack/DeployReporter.scala
@@ -29,7 +29,7 @@ object DeployReporter {
         val checkpointsAsSlack = checkpoints.map(c => s"<${c.details.url}|${c.name}>").mkString(", ")
         val json = Json.toJson(
           Message(
-            s"*Deployed to $checkpointsAsSlack: ${pr.title}*\n\n${pr.body.mkString}",
+            s"*Deployed to $checkpointsAsSlack: ${pr.title}*",
             Some(lib.Bot.user.login),
             Some(mergedBy.avatar_url),
             attachments


### PR DESCRIPTION
**Please vote on this issue using the [EMOJI REACTIONS](https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments)!**

Is the pull request body text in a slack message just irritating? The template used for DotCom frontend PRs has loads of comment text, which certainly is annoying to see in Slack- and will not be easy to filter out without parsing markdown.

 @sndrs [asks](https://theguardian.slack.com/archives/dotcom-push/p1483710077000149) if the entire body could be removed:

![image](https://cloud.githubusercontent.com/assets/52038/21721087/8defd504-d41e-11e6-9839-ebea8b6afffa.png)

**Please vote on this issue using the [EMOJI REACTIONS](https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments)!**

cc @TBonnin @tackley 



