### PR TITLE
Fix #50 - restrict commits associated with a Sentry release

### DIFF
--- a/app/lib/PullRequestCheckpointsStateChangeSummary.scala
+++ b/app/lib/PullRequestCheckpointsStateChangeSummary.scala
@@ -48,8 +48,8 @@ object PRCheckpointDetails {
            ): PRCheckpointDetails = {
 
     val everythingByCheckpoint: Map[Checkpoint, EverythingYouWantToKnowAboutACheckpoint] =
-      (for (snapsot <- snapshots) yield {
-        snapsot.checkpoint -> EverythingYouWantToKnowAboutACheckpoint(pr,snapsot,gitRepo)
+      (for (snapshot <- snapshots) yield {
+        snapshot.checkpoint -> EverythingYouWantToKnowAboutACheckpoint(pr,snapshot,gitRepo)
       }).toMap
 
     PRCheckpointDetails(pr,everythingByCheckpoint)

--- a/app/lib/RepoSnapshot.scala
+++ b/app/lib/RepoSnapshot.scala
@@ -253,7 +253,7 @@ case class RepoSnapshot(
           val mergeRef = lib.sentry.model.Ref(
             repo.repoId,
             sentryRelease.mergeCommit,
-            Some(pr.base.sha))
+            sentryRelease.mergeCommit.asRevCommit(new RevWalk(repoThreadLocal.reader())).getParents.headOption)
 
           sentry.createRelease(CreateRelease(
             sentryRelease.version,


### PR DESCRIPTION
See https://github.com/guardian/prout/issues/50 for more details. Using the first merge parent as the 'previous' commit restricts the commits to what we want: https://github.com/guardian/membership-frontend/compare/c4040b0800220063be16a089bbf5d571057311e7...257e7fc72d73d19d0c6c7d16ebb1ce8bfd1b73fd