### PR TITLE
Add support for Travis Pro

### DIFF
--- a/app/lib/RepoSnapshot.scala
+++ b/app/lib/RepoSnapshot.scala
@@ -42,7 +42,6 @@ import lib.travis.TravisApiClient
 import org.eclipse.jgit.lib.{ObjectId, Repository}
 import org.eclipse.jgit.revwalk.{RevCommit, RevWalk}
 import play.api.Logger
-
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
 import scala.concurrent.duration._
@@ -295,8 +294,7 @@ case class RepoSnapshot(
           travis <- afterSeen.travis
         } {
           logger.info(s"${pr.prId} going to do $travis")
-
-          travisApiClient.requestBuild(repo.full_name, travis, TriggerdByProutMsg, repo.default_branch)
+          travisApiClient.requestBuild(repo, travis, TriggerdByProutMsg)
         }
       }
 
@@ -376,7 +374,7 @@ case class RepoSnapshot(
       if (activeCheckpointsWithAfterSeenInstructions.size == 1) {
         prByMasterCommitOpt.foreach { masterPr =>
           repo.combinedStatusFor(repo.default_branch).map { masterStatus =>
-            TestingInProduction.updateFor(masterStatus, masterPr, activeCheckpointsWithAfterSeenInstructions.head.name)
+            TestingInProduction.updateFor(repo, masterStatus, masterPr, activeCheckpointsWithAfterSeenInstructions.head.name)
           }
         }
       }

--- a/app/lib/TestingInProduction.scala
+++ b/app/lib/TestingInProduction.scala
@@ -18,12 +18,10 @@ object TestingInProduction extends LazyLogging {
 
   val TriggerdByProutMsg = "Triggered by Prout"
 
-  def updateFor(repo: Repo, masterStatus: CombinedStatus, seenPr: PullRequest, checkpoint: String): Future[Unit] = {
+  def updateFor(repo: Repo, masterStatus: CombinedStatus, seenPr: PullRequest, checkpoint: String): Future[Unit] =
     buildTriggeredByProut(repo, masterStatus).map { proutBuildStatusOpt =>
       proutBuildStatusOpt.foreach(status => setTestResult(seenPr, checkpoint, status))
     }
-  }
-
 
   val CompletedTravisBuildStates = Set("passed", "failed")
 

--- a/app/lib/travis/TravisApiClient.scala
+++ b/app/lib/travis/TravisApiClient.scala
@@ -36,7 +36,7 @@ class TravisApiClient(githubToken: String) extends LazyLogging {
   }
 
   case object TravisProClient extends TravisApi {
-    override val baseEndpoint = Uri.parse("https://api.travis-ci.org")
+    override val baseEndpoint = Uri.parse("https://api.travis-ci.com")
     override val authTokenSupplier = new AuthTokenSupplier[String](auth(githubToken).map(_.get.access_token))
   }
 

--- a/app/lib/travis/TravisApiClient.scala
+++ b/app/lib/travis/TravisApiClient.scala
@@ -1,15 +1,19 @@
 package lib.travis
 
 import java.net.URLEncoder
-import akka.agent.Agent
+
 import com.madgag.okhttpscala._
 import com.madgag.scalagithub.model.Repo
 import com.netaporter.uri.Uri
+import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
+import lib.travis.TravisApi.BuildResponse.CompletedBuildStates
+import lib.travis.TravisApi._
 import okhttp3.Request.Builder
 import okhttp3._
-import play.api.libs.json.Json.toJson
+import play.api.libs.json.Json.{prettyPrint, toJson}
 import play.api.libs.json._
+
 import scala.collection.convert.decorateAsJava._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -18,51 +22,25 @@ object OkHttp {
   val client = new OkHttpClient
 }
 
-sealed trait TravisApi extends LazyLogging {
+object TravisApi {
 
-  val baseEndpoint: Uri
+  import play.api.Play.current
 
-  val JsonMediaType = MediaType.parse("application/json; charset=utf-8")
+  private val config: Config = play.api.Play.configuration.underlying
+
+  def clientFor(offering: TravisCIOffering): TravisApiClient = {
+    val authToken = config.getString(s"travis.token.${offering.name}")
+    TravisApiClient(offering, authToken)
+  }
+
+  def clientFor(repo: Repo): TravisApiClient = TravisApi.clientFor(TravisCIOffering.forRepo(repo))
+
 
   val DefaultJsonApiHeaders: Seq[(String, String)] = Seq(
     "User-Agent" -> "Travis access by Prout (https://github.com/guardian/prout)",
     "Content-Type" -> "application/json",
-    "Accept" -> "application/vnd.travis-ci.2+json"
+    "Travis-API-Version" -> "3"
   )
-
-  def getJson[Resp](path: String, extraHeaders: Seq[(String, String)])(implicit rResp: Reads[Resp]): Future[JsResult[Resp]] = readResponseFrom(
-    new Builder().url(baseEndpoint + path)
-    .headers(headersContainer(DefaultJsonApiHeaders))
-    .get()
-    .build())
-
-  def postJson[Req, Resp](path: String, reqBody: Req, extraHeaders: Seq[(String, String)] = Seq.empty)(implicit wReq: Writes[Req], rResp: Reads[Resp]): Future[JsResult[Resp]] = {
-    readResponseFrom(new Builder().url(baseEndpoint + path)
-      .headers(headersContainer(DefaultJsonApiHeaders ++ extraHeaders))
-      .post(RequestBody.create(JsonMediaType, toJson(reqBody).toString))
-      .build())
-  }
-
-  def headersContainer(headers: Seq[(String, String)]) = Headers.of(headers.toMap.asJava)
-
-  def readResponseFrom[Resp](request: Request)(implicit rResp: Reads[Resp]): Future[JsResult[Resp]] = {
-    logger.info(s"${request.method()} - ${request.url.encodedPath}")
-    OkHttp.client.execute(request) { resp => Json.parse(resp.body().byteStream()).validate[Resp] }
-  }
-
-  case class AuthRequest(github_token: String)
-
-  object AuthRequest {
-    implicit val writesAuthRequest = Json.writes[AuthRequest]
-  }
-
-  case class AuthResponse(access_token: String)
-
-  case class Build(id: Int, config: JsValue, state: String)
-
-  object Build {
-    implicit val readsBuild = Json.reads[Build]
-  }
 
   case class Commit(sha: String, message: String)
 
@@ -70,30 +48,54 @@ sealed trait TravisApi extends LazyLogging {
     implicit val readsCommit = Json.reads[Commit]
   }
 
-  case class BuildResponse(build: Build, commit: Commit)
+  case class BuildResponse(id: Long, state: String, commit: Commit) {
+    val isCompleted: Boolean = CompletedBuildStates.contains(state)
+  }
 
   object BuildResponse {
+
+    val CompletedBuildStates = Set("passed", "failed")
+
     implicit val readsBuildResponse = Json.reads[BuildResponse]
   }
+}
 
-  object AuthResponse {
-    implicit val readsAuthRequest = Json.reads[AuthResponse]
+
+case class TravisApiClient(offering: TravisCIOffering, authToken: String) extends LazyLogging {
+
+  val baseEndpoint: Uri = offering.baseApiEndpoint
+
+  val headers = Headers.of((DefaultJsonApiHeaders :+ "Authorization" -> s"token $authToken").toMap.asJava)
+
+  def getJson[Resp](path: String)(implicit rResp: Reads[Resp]): Future[JsResult[Resp]] = readResponseFrom(
+    new Builder().url(baseEndpoint + path)
+    .headers(headers)
+    .get()
+    .build())
+
+  def postJson[Req, Resp](path: String, reqBody: Req)(implicit wReq: Writes[Req], rResp: Reads[Resp]): Future[JsResult[Resp]] = {
+    readResponseFrom(new Builder().url(baseEndpoint + path)
+      .headers(headers)
+      .post(RequestBody.create(JsonMediaType, toJson(reqBody).toString))
+      .build())
   }
 
-  def auth(githubToken: String) = postJson[AuthRequest, AuthResponse]("/auth/github", AuthRequest(githubToken))
+  def readResponseFrom[Resp](request: Request)(implicit rResp: Reads[Resp]): Future[JsResult[Resp]] = {
+    val requestDescription = s"${request.method()} - ${request.url.encodedPath}"
+    logger.info(requestDescription)
+    OkHttp.client.execute(request) { resp =>
+      val json = Json.parse(resp.body().byteStream())
+      val jsResult = json.validate[Resp]
+      if (jsResult.isError) {
+        logger.error(s"$requestDescription got an invalid response ($jsResult):\n${prettyPrint(json)}")
+      }
+      jsResult
+    }
+  }
 
-  def build(buildId: String, authTokenSupplier: AuthTokenSupplier[String]) = for {
-    authToken <- authTokenSupplier.get()
-    response <- getJson[BuildResponse](
-      s"/builds/$buildId",
-      Seq(
-        "Authorization" -> s"token $authToken",
-        "Travis-API-Version" -> "3"
-      )
-    )
-  } yield response
+  def build(buildId: String) = getJson[BuildResponse](s"/build/$buildId")
 
-  def requestBuild(repoId: String, travis: TravisCI, message: String, buildBranch: String, authTokenSupplier: AuthTokenSupplier[String]) = {
+  def requestBuild(repoId: String, travis: TravisCI, message: String, buildBranch: String) = {
     val bodyJson = Json.obj(
       "request" -> Json.obj(
         "message" -> message,
@@ -102,75 +104,27 @@ sealed trait TravisApi extends LazyLogging {
       )
     )
 
-    for {
-      authToken <- authTokenSupplier.get()
-      response <- postJson[JsValue, JsValue](
-        s"/repo/${URLEncoder.encode(repoId, "UTF-8")}/requests",
-        bodyJson,
-        Seq(
-          "Authorization" -> s"token $authToken",
-          "Travis-API-Version" -> "3"
-        )
-      )
-    } yield response
+    postJson[JsValue, JsValue](s"/repo/${URLEncoder.encode(repoId, "UTF-8")}/requests", bodyJson)
   } andThen { case respTry => logger.info(s"requestBuild on $repoId response=$respTry") }
 
-  def authSupplier(githubToken: String) = new AuthTokenSupplier[String](auth(githubToken).map(_.get.access_token))
-
 }
 
-case object TravisCiEnvironment extends TravisApi {
-  override val baseEndpoint = Uri.parse("https://api.travis-ci.org")
+sealed trait TravisCIOffering {
+  val name: String
+  val baseApiEndpoint: Uri
 }
 
-case object TravisProEnvironment extends TravisApi {
-  override val baseEndpoint = Uri.parse("https://api.travis-ci.com")
-}
-
-class TravisApiClient(githubToken: String) {
-
-  val ciAuth = TravisCiEnvironment.authSupplier(githubToken)
-  val proAuth = TravisProEnvironment.authSupplier(githubToken)
-
-  case class TravisEnvironment(travisApi: TravisApi, authTokenSupplier: AuthTokenSupplier[String])
-
-  def chooseEnvironment(repo: Repo): TravisEnvironment = {
-    if (repo.`private`) {
-      TravisEnvironment(TravisProEnvironment, proAuth)
-    } else {
-      TravisEnvironment(TravisCiEnvironment, ciAuth)
-    }
+object TravisCIOffering {
+  case object OpenSource extends TravisCIOffering {
+    val name = "opensource"
+    val baseApiEndpoint = Uri.parse("https://api.travis-ci.org")
   }
 
-  def build(repo: Repo, buildId: String) = {
-    val environment: TravisEnvironment = chooseEnvironment(repo)
-    environment.travisApi.build(buildId, environment.authTokenSupplier)
+  case object Commercial extends TravisCIOffering {
+    val name = "commercial"
+    val baseApiEndpoint = Uri.parse("https://api.travis-ci.com")
   }
 
-  def requestBuild(repo: Repo, travis: TravisCI, message: String) = {
-    val environment: TravisEnvironment = chooseEnvironment(repo)
-    environment.travisApi.requestBuild(repo.full_name, travis, message, repo.default_branch, environment.authTokenSupplier)
-  }
-
+  def forRepo(repo: Repo): TravisCIOffering = if (repo.`private`) Commercial else OpenSource
 }
 
-class AuthTokenSupplier[T](generateToken: => Future[T]) {
-
-  private val agent: Agent[Future[T]] = Agent(generateToken)
-
-  /**
-    * If no refresh is currently running, start a new one, return that future
-    * If a refresh is currently running, return the existing future
-    */
-  def refresh(): Future[T] = for {
-    refreshAlteringFuture <- agent.alter { currentRefresh => if (currentRefresh.isCompleted) generateToken else currentRefresh }
-    refreshFuture <- refreshAlteringFuture
-  } yield refreshFuture
-
-  /*
-   * If a refresh is currently running, return the refresh future
-   * If a token is present, return it
-   * Otherwise, return a refresh()
-   */
-  def get(): Future[T] = agent.get()
-}

--- a/app/lib/travis/TravisApiClient.scala
+++ b/app/lib/travis/TravisApiClient.scala
@@ -1,16 +1,15 @@
 package lib.travis
 
 import java.net.URLEncoder
-
 import akka.agent.Agent
 import com.madgag.okhttpscala._
+import com.madgag.scalagithub.model.Repo
 import com.netaporter.uri.Uri
 import com.typesafe.scalalogging.LazyLogging
 import okhttp3.Request.Builder
 import okhttp3._
 import play.api.libs.json.Json.toJson
 import play.api.libs.json._
-
 import scala.collection.convert.decorateAsJava._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -19,114 +18,147 @@ class TravisApiClient(githubToken: String) extends LazyLogging {
 
   val okHttpClient = new OkHttpClient
 
-  val baseEndpoint = Uri.parse("https://api.travis-ci.org")
-
-  val JsonMediaType = MediaType.parse("application/json; charset=utf-8")
-
-  val DefaultJsonApiHeaders: Seq[(String, String)] = Seq(
-    "User-Agent" -> "Travis access by Prout (https://github.com/guardian/prout)",
-    "Content-Type" -> "application/json",
-    "Accept" -> "application/vnd.travis-ci.2+json"
-  )
-
-  def getJson[Resp](path: String)(implicit rResp: Reads[Resp]): Future[JsResult[Resp]] = readResponseFrom(
-    new Builder().url(baseEndpoint + path)
-    .headers(headersContainer(DefaultJsonApiHeaders))
-    .get()
-    .build())
-
-  def postJson[Req, Resp](path: String, reqBody: Req, extraHeaders: Seq[(String, String)] = Seq.empty)(implicit wReq: Writes[Req], rResp: Reads[Resp]): Future[JsResult[Resp]] = {
-    readResponseFrom(new Builder().url(baseEndpoint + path)
-      .headers(headersContainer(DefaultJsonApiHeaders ++ extraHeaders))
-      .post(RequestBody.create(JsonMediaType, toJson(reqBody).toString))
-      .build())
+  def chooseEnvironment(repo: Repo): TravisApi = {
+    if (repo.`private`) TravisProClient else TravisCiClient
   }
 
-  def headersContainer(headers: Seq[(String, String)]) = Headers.of(headers.toMap.asJava)
-
-  def readResponseFrom[Resp](request: Request)(implicit rResp: Reads[Resp]): Future[JsResult[Resp]] = {
-    logger.info(s"${request.method()} - ${request.url.encodedPath}")
-    okHttpClient.execute(request) { resp => Json.parse(resp.body().byteStream()).validate[Resp] }
+  def build(repo: Repo, buildId: String) = {
+    chooseEnvironment(repo).build(buildId)
   }
 
-  case class AuthRequest(github_token: String)
-
-  object AuthRequest {
-    implicit val writesAuthRequest = Json.writes[AuthRequest]
+  def requestBuild(repo: Repo, travis: TravisCI, message: String) = {
+    chooseEnvironment(repo).requestBuild(repo.full_name, travis, message, repo.default_branch)
   }
 
-  case class AuthResponse(access_token: String)
-
-  case class Build(id: Int, config: JsValue, state: String)
-
-  object Build {
-    implicit val readsBuild = Json.reads[Build]
+  case object TravisCiClient extends TravisApi {
+    override val baseEndpoint = Uri.parse("https://api.travis-ci.org")
+    override val authTokenSupplier = new AuthTokenSupplier[String](auth(githubToken).map(_.get.access_token))
   }
 
-  case class Commit(sha: String, message: String)
-
-  object Commit {
-    implicit val readsCommit = Json.reads[Commit]
+  case object TravisProClient extends TravisApi {
+    override val baseEndpoint = Uri.parse("https://api.travis-ci.org")
+    override val authTokenSupplier = new AuthTokenSupplier[String](auth(githubToken).map(_.get.access_token))
   }
 
-  case class BuildResponse(build: Build, commit: Commit)
+  sealed trait TravisApi extends LazyLogging {
 
-  object BuildResponse {
-    implicit val readsBuildResponse = Json.reads[BuildResponse]
-  }
+    val baseEndpoint: Uri
+    val authTokenSupplier: AuthTokenSupplier[String]
+    val JsonMediaType = MediaType.parse("application/json; charset=utf-8")
 
-  object AuthResponse {
-    implicit val readsAuthRequest = Json.reads[AuthResponse]
-  }
-
-  def auth(githubToken: String) = postJson[AuthRequest, AuthResponse]("/auth/github", AuthRequest(githubToken))
-
-  def build(buildId: String) = getJson[BuildResponse](s"/builds/$buildId")
-
-  def requestBuild(repoId: String, travis: TravisCI, message: String, buildBranch: String) = {
-    val bodyJson = Json.obj(
-      "request" -> Json.obj(
-        "message" -> message,
-        "branch" -> buildBranch,
-        "config" -> travis.config
-      )
+    val DefaultJsonApiHeaders: Seq[(String, String)] = Seq(
+      "User-Agent" -> "Travis access by Prout (https://github.com/guardian/prout)",
+      "Content-Type" -> "application/json",
+      "Accept" -> "application/vnd.travis-ci.2+json"
     )
 
-    for {
+    def getJson[Resp](path: String, extraHeaders: Seq[(String, String)])(implicit rResp: Reads[Resp]): Future[JsResult[Resp]] = {
+      readResponseFrom(new Builder().url(baseEndpoint + path)
+        .headers(headersContainer(DefaultJsonApiHeaders))
+        .get()
+        .build())
+    }
+
+    def postJson[Req, Resp](path: String, reqBody: Req, extraHeaders: Seq[(String, String)] = Seq.empty)(implicit wReq: Writes[Req], rResp: Reads[Resp]): Future[JsResult[Resp]] = {
+      readResponseFrom(new Builder().url(baseEndpoint + path)
+        .headers(headersContainer(DefaultJsonApiHeaders ++ extraHeaders))
+        .post(RequestBody.create(JsonMediaType, toJson(reqBody).toString))
+        .build())
+    }
+
+    def headersContainer(headers: Seq[(String, String)]) = Headers.of(headers.toMap.asJava)
+
+    def readResponseFrom[Resp](request: Request)(implicit rResp: Reads[Resp]): Future[JsResult[Resp]] = {
+      logger.info(s"${request.method()} - ${request.url.encodedPath}")
+      okHttpClient.execute(request) { resp => Json.parse(resp.body().byteStream()).validate[Resp] }
+    }
+
+    case class AuthRequest(github_token: String)
+
+    object AuthRequest {
+      implicit val writesAuthRequest = Json.writes[AuthRequest]
+    }
+
+    case class AuthResponse(access_token: String)
+
+    case class Build(id: Int, config: JsValue, state: String)
+
+    object Build {
+      implicit val readsBuild = Json.reads[Build]
+    }
+
+    case class Commit(sha: String, message: String)
+
+    object Commit {
+      implicit val readsCommit = Json.reads[Commit]
+    }
+
+    case class BuildResponse(build: Build, commit: Commit)
+
+    object BuildResponse {
+      implicit val readsBuildResponse = Json.reads[BuildResponse]
+    }
+
+    object AuthResponse {
+      implicit val readsAuthRequest = Json.reads[AuthResponse]
+    }
+
+    def auth(githubToken: String) = postJson[AuthRequest, AuthResponse]("/auth/github", AuthRequest(githubToken))
+
+    def build(buildId: String) = for {
       authToken <- authTokenSupplier.get()
-      response <- postJson[JsValue, JsValue](
-        s"/repo/${URLEncoder.encode(repoId, "UTF-8")}/requests",
-        bodyJson,
+      response <- getJson[BuildResponse](
+        s"/builds/$buildId",
         Seq(
           "Authorization" -> s"token $authToken",
           "Travis-API-Version" -> "3"
         )
       )
     } yield response
-  } andThen { case respTry => logger.info(s"requestBuild on $repoId response=$respTry") }
 
+    def requestBuild(repoId: String, travis: TravisCI, message: String, buildBranch: String) = {
+      val bodyJson = Json.obj(
+        "request" -> Json.obj(
+          "message" -> message,
+          "branch" -> buildBranch,
+          "config" -> travis.config
+        )
+      )
 
-  val authTokenSupplier = new AuthTokenSupplier[String](auth(githubToken).map(_.get.access_token))
+      for {
+        authToken <- authTokenSupplier.get()
+        response <- postJson[JsValue, JsValue](
+          s"/repo/${URLEncoder.encode(repoId, "UTF-8")}/requests",
+          bodyJson,
+          Seq(
+            "Authorization" -> s"token $authToken",
+            "Travis-API-Version" -> "3"
+          )
+        )
+      } yield response
+    } andThen { case respTry => logger.info(s"requestBuild on $repoId response=$respTry") }
 
-  class AuthTokenSupplier[T](generateToken: => Future[T]) {
+    class AuthTokenSupplier[T](generateToken: => Future[T]) {
 
-    private val agent: Agent[Future[T]] = Agent(generateToken)
+      private val agent: Agent[Future[T]] = Agent(generateToken)
 
-    /**
-     * If no refresh is currently running, start a new one, return that future
-     * If a refresh is currently running, return the existing future
-     */
-    def refresh(): Future[T] = for {
-      refreshAlteringFuture <- agent.alter { currentRefresh => if (currentRefresh.isCompleted) generateToken else currentRefresh }
-      refreshFuture <- refreshAlteringFuture
-    } yield refreshFuture
+      /**
+        * If no refresh is currently running, start a new one, return that future
+        * If a refresh is currently running, return the existing future
+        */
+      def refresh(): Future[T] = for {
+        refreshAlteringFuture <- agent.alter { currentRefresh => if (currentRefresh.isCompleted) generateToken else currentRefresh }
+        refreshFuture <- refreshAlteringFuture
+      } yield refreshFuture
 
-    /*
-     * If a refresh is currently running, return the refresh future
-     * If a token is present, return it
-     * Otherwise, return a refresh()
-     */
-    def get(): Future[T] = agent.get()
+      /*
+       * If a refresh is currently running, return the refresh future
+       * If a token is present, return it
+       * Otherwise, return a refresh()
+       */
+      def get(): Future[T] = agent.get()
+    }
+
   }
 
 }

--- a/app/lib/travis/TravisApiClient.scala
+++ b/app/lib/travis/TravisApiClient.scala
@@ -32,9 +32,9 @@ sealed trait TravisApi extends LazyLogging {
 
   def getJson[Resp](path: String, extraHeaders: Seq[(String, String)])(implicit rResp: Reads[Resp]): Future[JsResult[Resp]] = readResponseFrom(
     new Builder().url(baseEndpoint + path)
-      .headers(headersContainer(DefaultJsonApiHeaders))
-      .get()
-      .build())
+    .headers(headersContainer(DefaultJsonApiHeaders))
+    .get()
+    .build())
 
   def postJson[Req, Resp](path: String, reqBody: Req, extraHeaders: Seq[(String, String)] = Seq.empty)(implicit wReq: Writes[Req], rResp: Reads[Resp]): Future[JsResult[Resp]] = {
     readResponseFrom(new Builder().url(baseEndpoint + path)
@@ -127,7 +127,7 @@ case object TravisProEnvironment extends TravisApi {
   override val baseEndpoint = Uri.parse("https://api.travis-ci.com")
 }
 
-class TravisApiClient(githubToken: String) extends LazyLogging {
+class TravisApiClient(githubToken: String) {
 
   val ciAuth = TravisCiEnvironment.authSupplier(githubToken)
   val proAuth = TravisProEnvironment.authSupplier(githubToken)

--- a/app/lib/travis/TravisApiClient.scala
+++ b/app/lib/travis/TravisApiClient.scala
@@ -14,151 +14,163 @@ import scala.collection.convert.decorateAsJava._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class TravisApiClient(githubToken: String) extends LazyLogging {
+object OkHttp {
+  val client = new OkHttpClient
+}
 
-  val okHttpClient = new OkHttpClient
+sealed trait TravisApi extends LazyLogging {
 
-  def chooseEnvironment(repo: Repo): TravisApi = {
-    if (repo.`private`) TravisProClient else TravisCiClient
+  val baseEndpoint: Uri
+
+  val JsonMediaType = MediaType.parse("application/json; charset=utf-8")
+
+  val DefaultJsonApiHeaders: Seq[(String, String)] = Seq(
+    "User-Agent" -> "Travis access by Prout (https://github.com/guardian/prout)",
+    "Content-Type" -> "application/json",
+    "Accept" -> "application/vnd.travis-ci.2+json"
+  )
+
+  def getJson[Resp](path: String, extraHeaders: Seq[(String, String)])(implicit rResp: Reads[Resp]): Future[JsResult[Resp]] = readResponseFrom(
+    new Builder().url(baseEndpoint + path)
+      .headers(headersContainer(DefaultJsonApiHeaders))
+      .get()
+      .build())
+
+  def postJson[Req, Resp](path: String, reqBody: Req, extraHeaders: Seq[(String, String)] = Seq.empty)(implicit wReq: Writes[Req], rResp: Reads[Resp]): Future[JsResult[Resp]] = {
+    readResponseFrom(new Builder().url(baseEndpoint + path)
+      .headers(headersContainer(DefaultJsonApiHeaders ++ extraHeaders))
+      .post(RequestBody.create(JsonMediaType, toJson(reqBody).toString))
+      .build())
   }
 
-  def build(repo: Repo, buildId: String) = {
-    chooseEnvironment(repo).build(buildId)
+  def headersContainer(headers: Seq[(String, String)]) = Headers.of(headers.toMap.asJava)
+
+  def readResponseFrom[Resp](request: Request)(implicit rResp: Reads[Resp]): Future[JsResult[Resp]] = {
+    logger.info(s"${request.method()} - ${request.url.encodedPath}")
+    OkHttp.client.execute(request) { resp => Json.parse(resp.body().byteStream()).validate[Resp] }
   }
 
-  def requestBuild(repo: Repo, travis: TravisCI, message: String) = {
-    chooseEnvironment(repo).requestBuild(repo.full_name, travis, message, repo.default_branch)
+  case class AuthRequest(github_token: String)
+
+  object AuthRequest {
+    implicit val writesAuthRequest = Json.writes[AuthRequest]
   }
 
-  case object TravisCiClient extends TravisApi {
-    override val baseEndpoint = Uri.parse("https://api.travis-ci.org")
-    override val authTokenSupplier = new AuthTokenSupplier[String](auth(githubToken).map(_.get.access_token))
+  case class AuthResponse(access_token: String)
+
+  case class Build(id: Int, config: JsValue, state: String)
+
+  object Build {
+    implicit val readsBuild = Json.reads[Build]
   }
 
-  case object TravisProClient extends TravisApi {
-    override val baseEndpoint = Uri.parse("https://api.travis-ci.com")
-    override val authTokenSupplier = new AuthTokenSupplier[String](auth(githubToken).map(_.get.access_token))
+  case class Commit(sha: String, message: String)
+
+  object Commit {
+    implicit val readsCommit = Json.reads[Commit]
   }
 
-  sealed trait TravisApi extends LazyLogging {
+  case class BuildResponse(build: Build, commit: Commit)
 
-    val baseEndpoint: Uri
-    val authTokenSupplier: AuthTokenSupplier[String]
-    val JsonMediaType = MediaType.parse("application/json; charset=utf-8")
+  object BuildResponse {
+    implicit val readsBuildResponse = Json.reads[BuildResponse]
+  }
 
-    val DefaultJsonApiHeaders: Seq[(String, String)] = Seq(
-      "User-Agent" -> "Travis access by Prout (https://github.com/guardian/prout)",
-      "Content-Type" -> "application/json",
-      "Accept" -> "application/vnd.travis-ci.2+json"
+  object AuthResponse {
+    implicit val readsAuthRequest = Json.reads[AuthResponse]
+  }
+
+  def auth(githubToken: String) = postJson[AuthRequest, AuthResponse]("/auth/github", AuthRequest(githubToken))
+
+  def build(buildId: String, authTokenSupplier: AuthTokenSupplier[String]) = for {
+    authToken <- authTokenSupplier.get()
+    response <- getJson[BuildResponse](
+      s"/builds/$buildId",
+      Seq(
+        "Authorization" -> s"token $authToken",
+        "Travis-API-Version" -> "3"
+      )
+    )
+  } yield response
+
+  def requestBuild(repoId: String, travis: TravisCI, message: String, buildBranch: String, authTokenSupplier: AuthTokenSupplier[String]) = {
+    val bodyJson = Json.obj(
+      "request" -> Json.obj(
+        "message" -> message,
+        "branch" -> buildBranch,
+        "config" -> travis.config
+      )
     )
 
-    def getJson[Resp](path: String, extraHeaders: Seq[(String, String)])(implicit rResp: Reads[Resp]): Future[JsResult[Resp]] = {
-      readResponseFrom(new Builder().url(baseEndpoint + path)
-        .headers(headersContainer(DefaultJsonApiHeaders))
-        .get()
-        .build())
-    }
-
-    def postJson[Req, Resp](path: String, reqBody: Req, extraHeaders: Seq[(String, String)] = Seq.empty)(implicit wReq: Writes[Req], rResp: Reads[Resp]): Future[JsResult[Resp]] = {
-      readResponseFrom(new Builder().url(baseEndpoint + path)
-        .headers(headersContainer(DefaultJsonApiHeaders ++ extraHeaders))
-        .post(RequestBody.create(JsonMediaType, toJson(reqBody).toString))
-        .build())
-    }
-
-    def headersContainer(headers: Seq[(String, String)]) = Headers.of(headers.toMap.asJava)
-
-    def readResponseFrom[Resp](request: Request)(implicit rResp: Reads[Resp]): Future[JsResult[Resp]] = {
-      logger.info(s"${request.method()} - ${request.url.encodedPath}")
-      okHttpClient.execute(request) { resp => Json.parse(resp.body().byteStream()).validate[Resp] }
-    }
-
-    case class AuthRequest(github_token: String)
-
-    object AuthRequest {
-      implicit val writesAuthRequest = Json.writes[AuthRequest]
-    }
-
-    case class AuthResponse(access_token: String)
-
-    case class Build(id: Int, config: JsValue, state: String)
-
-    object Build {
-      implicit val readsBuild = Json.reads[Build]
-    }
-
-    case class Commit(sha: String, message: String)
-
-    object Commit {
-      implicit val readsCommit = Json.reads[Commit]
-    }
-
-    case class BuildResponse(build: Build, commit: Commit)
-
-    object BuildResponse {
-      implicit val readsBuildResponse = Json.reads[BuildResponse]
-    }
-
-    object AuthResponse {
-      implicit val readsAuthRequest = Json.reads[AuthResponse]
-    }
-
-    def auth(githubToken: String) = postJson[AuthRequest, AuthResponse]("/auth/github", AuthRequest(githubToken))
-
-    def build(buildId: String) = for {
+    for {
       authToken <- authTokenSupplier.get()
-      response <- getJson[BuildResponse](
-        s"/builds/$buildId",
+      response <- postJson[JsValue, JsValue](
+        s"/repo/${URLEncoder.encode(repoId, "UTF-8")}/requests",
+        bodyJson,
         Seq(
           "Authorization" -> s"token $authToken",
           "Travis-API-Version" -> "3"
         )
       )
     } yield response
+  } andThen { case respTry => logger.info(s"requestBuild on $repoId response=$respTry") }
 
-    def requestBuild(repoId: String, travis: TravisCI, message: String, buildBranch: String) = {
-      val bodyJson = Json.obj(
-        "request" -> Json.obj(
-          "message" -> message,
-          "branch" -> buildBranch,
-          "config" -> travis.config
-        )
-      )
+  def authSupplier(githubToken: String) = new AuthTokenSupplier[String](auth(githubToken).map(_.get.access_token))
 
-      for {
-        authToken <- authTokenSupplier.get()
-        response <- postJson[JsValue, JsValue](
-          s"/repo/${URLEncoder.encode(repoId, "UTF-8")}/requests",
-          bodyJson,
-          Seq(
-            "Authorization" -> s"token $authToken",
-            "Travis-API-Version" -> "3"
-          )
-        )
-      } yield response
-    } andThen { case respTry => logger.info(s"requestBuild on $repoId response=$respTry") }
+}
 
-    class AuthTokenSupplier[T](generateToken: => Future[T]) {
+case object TravisCiEnvironment extends TravisApi {
+  override val baseEndpoint = Uri.parse("https://api.travis-ci.org")
+}
 
-      private val agent: Agent[Future[T]] = Agent(generateToken)
+case object TravisProEnvironment extends TravisApi {
+  override val baseEndpoint = Uri.parse("https://api.travis-ci.com")
+}
 
-      /**
-        * If no refresh is currently running, start a new one, return that future
-        * If a refresh is currently running, return the existing future
-        */
-      def refresh(): Future[T] = for {
-        refreshAlteringFuture <- agent.alter { currentRefresh => if (currentRefresh.isCompleted) generateToken else currentRefresh }
-        refreshFuture <- refreshAlteringFuture
-      } yield refreshFuture
+class TravisApiClient(githubToken: String) extends LazyLogging {
 
-      /*
-       * If a refresh is currently running, return the refresh future
-       * If a token is present, return it
-       * Otherwise, return a refresh()
-       */
-      def get(): Future[T] = agent.get()
+  val ciAuth = TravisCiEnvironment.authSupplier(githubToken)
+  val proAuth = TravisProEnvironment.authSupplier(githubToken)
+
+  case class TravisEnvironment(travisApi: TravisApi, authTokenSupplier: AuthTokenSupplier[String])
+
+  def chooseEnvironment(repo: Repo): TravisEnvironment = {
+    if (repo.`private`) {
+      TravisEnvironment(TravisProEnvironment, proAuth)
+    } else {
+      TravisEnvironment(TravisCiEnvironment, ciAuth)
     }
-
   }
 
+  def build(repo: Repo, buildId: String) = {
+    val environment: TravisEnvironment = chooseEnvironment(repo)
+    environment.travisApi.build(buildId, environment.authTokenSupplier)
+  }
+
+  def requestBuild(repo: Repo, travis: TravisCI, message: String) = {
+    val environment: TravisEnvironment = chooseEnvironment(repo)
+    environment.travisApi.requestBuild(repo.full_name, travis, message, repo.default_branch, environment.authTokenSupplier)
+  }
+
+}
+
+class AuthTokenSupplier[T](generateToken: => Future[T]) {
+
+  private val agent: Agent[Future[T]] = Agent(generateToken)
+
+  /**
+    * If no refresh is currently running, start a new one, return that future
+    * If a refresh is currently running, return the existing future
+    */
+  def refresh(): Future[T] = for {
+    refreshAlteringFuture <- agent.alter { currentRefresh => if (currentRefresh.isCompleted) generateToken else currentRefresh }
+    refreshFuture <- refreshAlteringFuture
+  } yield refreshFuture
+
+  /*
+   * If a refresh is currently running, return the refresh future
+   * If a token is present, return it
+   * Otherwise, return a refresh()
+   */
+  def get(): Future[T] = agent.get()
 }

--- a/app/lib/travis/TravisCI.scala
+++ b/app/lib/travis/TravisCI.scala
@@ -1,9 +1,20 @@
 package lib.travis
 
+import com.madgag.scalagithub.model.Status
+import com.netaporter.uri.Uri
+import com.typesafe.scalalogging.LazyLogging
+import lib.PostDeployActions.GitHubCompletionStates
 import play.api.libs.json.{JsObject, Json}
 
 case class TravisCI(config: JsObject)
 
-object TravisCI {
+object TravisCI extends LazyLogging {
   implicit val readsTravisCI = Json.reads[TravisCI]
+
+  def buildIdFrom(buildStatus: Status) = Uri.parse(buildStatus.target_url).pathParts.last.part
+
+  def extractStatusesOfCompletedTravisBuildsFrom(statuses: Seq[Status]): Seq[Status] = statuses.filter {
+    status => status.context.startsWith("continuous-integration/travis-ci") && GitHubCompletionStates.contains(status.state)
+  }
+
 }

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
   "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.3-1",
   "org.webjars.bower" % "octicons" % "3.1.0",
-  "com.madgag" %% "play-git-hub" % "4.4",
+  "com.madgag" %% "play-git-hub" % "4.5",
   "com.madgag.scala-git" %% "scala-git-test" % "3.0" % "test",
   "org.scalatestplus" %% "play" % "1.4.0" % "test"
 )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -17,6 +17,11 @@ github {
   clientSecret=${?GITHUB_APP_CLIENT_SECRET}
 }
 
+travis.token {
+  opensource=${?PROUT_TRAVIS_TOKEN_OPENSOURCE}
+  commercial=${?PROUT_TRAVIS_TOKEN_COMMERCIAL}
+}
+
 sentry {
   org=${?SENTRY_ORG}
   token=${?SENTRY_ACCESS_TOKEN}

--- a/test/FunctionalSpec.scala
+++ b/test/FunctionalSpec.scala
@@ -167,7 +167,7 @@ class FunctionalSpec extends Helpers with TestRepoCreation with Inside {
             val status = combinedStatus.statuses.find(_.context.startsWith("continuous-integration/travis-ci")).get
 
             val buildId = Uri.parse(status.target_url).pathParts.last.part
-            whenReady(t.build(buildId)) {
+            whenReady(t.build(githubRepo, buildId)) {
               buildResponse => inside(buildResponse) {
                 case JsSuccess(b, _) =>
                   inside (b.build.config \ "script") { case JsDefined(script) =>

--- a/test/FunctionalSpec.scala
+++ b/test/FunctionalSpec.scala
@@ -3,15 +3,17 @@ import java.util.Base64
 import com.madgag.scalagithub.GitHub._
 import com.madgag.scalagithub.commands.{CreateFile, CreateRef}
 import com.madgag.scalagithub.model.{Repo, RepoId}
-import com.netaporter.uri.Uri
+import lib.PostDeployActions.githubStatusForLatestCompletedBuildTriggeredByProut
 import lib.RepoSnapshot.ClosedPRsMostlyRecentlyUpdated
 import lib._
-import lib.travis.TravisApiClient
+import lib.travis.{TravisApi, TravisCI}
 import org.eclipse.jgit.lib.ObjectId.zeroId
 import org.scalatest.Inside
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import play.api.libs.json.{JsDefined, JsString, JsSuccess}
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
 import scala.util.Random
 
 class FunctionalSpec extends Helpers with TestRepoCreation with Inside {
@@ -141,18 +143,7 @@ class FunctionalSpec extends Helpers with TestRepoCreation with Inside {
       val testUserLogin = github.getUser().futureValue.result.login
       val githubRepo: Repo = github.getRepo(RepoId(testUserLogin, "test-travis-builds")).futureValue
 
-      val branchName = System.currentTimeMillis().toString
-
-      val masterSha = shaForDefaultBranchOf(githubRepo)
-
-      val createdRef = githubRepo.refs.create(CreateRef(s"refs/heads/$branchName", masterSha)).futureValue
-      createdRef.objectId mustEqual masterSha
-
-      val newScratchFile = s"junk-folder/$branchName/${Random.alphanumeric.take(8).mkString}"
-      val fileContents = Base64.getEncoder.encodeToString("foo".getBytes)
-      githubRepo.contents2.put(newScratchFile, CreateFile("message", fileContents, Some(branchName))).futureValue
-
-      implicit val repoPR = mergePullRequestIn(githubRepo, branchName)
+      implicit val repoPR: RepoPR = mergeNewBranchIntoMasterFor(githubRepo)
 
       repoPR setCheckpointTo "master"
 
@@ -160,25 +151,42 @@ class FunctionalSpec extends Helpers with TestRepoCreation with Inside {
         labelsOn(_) must contain only "Seen-on-PROD"
       }
 
-      val t = new TravisApiClient(githubToken)
-      eventually {
-        whenReady(githubRepo.combinedStatusFor(githubRepo.default_branch)) {
-          combinedStatus =>
-            val status = combinedStatus.statuses.find(_.context.startsWith("continuous-integration/travis-ci")).get
-
-            val buildId = Uri.parse(status.target_url).pathParts.last.part
-            whenReady(t.build(githubRepo, buildId)) {
-              buildResponse => inside(buildResponse) {
-                case JsSuccess(b, _) =>
-                  inside (b.build.config \ "script") { case JsDefined(script) =>
-                    script mustEqual JsString("echo Prout - afterSeen script")
-                  }
-              }
+      val githubStatusOpt = eventually(Timeout(2.minutes)) {
+        whenReady(githubRepo.statusesFor(githubRepo.default_branch)) {
+          statuses =>
+            whenReady(githubStatusForLatestCompletedBuildTriggeredByProut(githubRepo, statuses)) {
+              statusOpt => statusOpt.value.state mustBe "success"
+                statusOpt
             }
         }
+      }
 
+      val t = TravisApi.clientFor(githubRepo)
 
+      val travisBuildId = TravisCI.buildIdFrom(githubStatusOpt.value)
+      eventually {
+        whenReady(t.build(travisBuildId)) { buildResponse =>
+          inside(buildResponse) {
+            case JsSuccess(b, _) =>
+              b.state mustEqual "passed"
+          }
+        }
       }
     }
+  }
+
+  private def mergeNewBranchIntoMasterFor(githubRepo: Repo): RepoPR = {
+    val branchName = System.currentTimeMillis().toString
+
+    val masterSha = shaForDefaultBranchOf(githubRepo)
+
+    val createdRef = githubRepo.refs.create(CreateRef(s"refs/heads/$branchName", masterSha)).futureValue
+    createdRef.objectId mustEqual masterSha
+
+    val newScratchFile = s"junk-folder/$branchName/${Random.alphanumeric.take(8).mkString}"
+    val fileContents = Base64.getEncoder.encodeToString("foo".getBytes)
+    githubRepo.contents2.put(newScratchFile, CreateFile("message", fileContents, Some(branchName))).futureValue
+
+    mergePullRequestIn(githubRepo, branchName)
   }
 }

--- a/test/resources/logback.xml
+++ b/test/resources/logback.xml
@@ -15,14 +15,6 @@
         </encoder>
     </appender>
 
-    <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="FILE" />
-    </appender>
-
-    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="STDOUT" />
-    </appender>
-
     <logger name="play" level="INFO" />
     <logger name="application" level="DEBUG" />
 
@@ -33,7 +25,8 @@
     <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
 
     <root level="INFO">
-        <appender-ref ref="ASYNCSTDOUT" />
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE" />
     </root>
 
 </configuration>


### PR DESCRIPTION
The Travis support in Prout currently only works with Travis CI. However, we want to use Prout to run post-deployment tests for a private project, which means that we need to add compatibility for the Travis Pro API.

There's some more information on the different API endpoints here:
https://docs.travis-ci.com/api

This PR allows Prout to call the correct API, based on the private/public status of the repo being scanned.