### PR TITLE
Remove unused BodyParser code in prep for Play 2.8

### DIFF
--- a/app/lib/actions/Parsers.scala
+++ b/app/lib/actions/Parsers.scala
@@ -28,59 +28,10 @@ object Parsers {
     Logger.debug("HMAC Signatures matched!")
   }
 
-  def githubHookRepository: BodyParser[RepoId] = tolerantXHubSigned[RepoId](RepoSecretKey.sharedSecretForRepo, "json", 128 * 1024, "Invalid Json") {
-    (requestHeader, bytes) => parseGitHubHookJson(Json.parse(bytes))
-  }
-
   def parseGitHubHookJson(jsValue: JsValue): RepoId =
     (jsValue \ "repository" \ "full_name").validate[String].map(RepoId.from).get
 
-  def githubHookJson(sharedSecret: String) = tolerantXHubSigned[JsValue](_ => sharedSecret, "json", 128 * 1024, "Invalid Json") {
-    (requestHeader, bytes) => Json.parse(bytes)
-  }
-
   type FullBodyParser[+A] = (RequestHeader, Array[Byte]) => Either[Result, A]
-
-  /*
-  The 'X-Hub-Signature' header is defined by the PubSubHubbub Protocol:
-
-  https://pubsubhubbub.googlecode.com/git/pubsubhubbub-core-0.4.html#authednotify ("8. Authenticated Content Distribution")
-
-   */
-  def tolerantXHubSigned[A](sharedSecret: A => String, name: String, maxLength: Int, errorMessage: String)(parser: (RequestHeader, Array[Byte]) => A): BodyParser[A] =
-    tolerantBodyParser[A]("json", maxLength, "Invalid Json") { (request, bytes) =>
-      val xHubSignature = request.headers("X-Hub-Signature").replaceFirst("sha1=", "")
-      val res: A = parser(request, bytes)
-      assertSecureEquals(xHubSignature, sign(bytes, sharedSecret(res).getBytes))
-      res
-    }
-
-  def tolerantBodyParser[A](name: String, maxLength: Int, errorMessage: String)(parser: (RequestHeader, Array[Byte]) => A): BodyParser[A] =
-    BodyParser(name + ", maxLength=" + maxLength) { request =>
-      import play.api.libs.iteratee.Execution.Implicits.trampoline
-
-      import scala.util.control.Exception._
-
-      val bodyParser: Iteratee[Array[Byte], Either[Result, Either[Future[Result], A]]] =
-        Traversable.takeUpTo[Array[Byte]](maxLength).transform(
-          Iteratee.consume[Array[Byte]]().map { bytes =>
-            allCatch[A].either {
-              parser(request, bytes)
-            }.left.map {
-              case NonFatal(e) =>
-                Future.successful(Results.BadRequest(errorMessage))
-              case t => throw t
-            }
-          }
-        ).flatMap(Iteratee.eofOrElse(Results.EntityTooLarge))
-
-      bodyParser.mapM {
-        case Left(tooLarge) => Future.successful(Left(tooLarge))
-        case Right(Left(badResult)) => badResult.map(Left.apply)
-        case Right(Right(body)) => Future.successful(Right(body))
-      }
-    }
-
 
   def sign(message: Array[Byte], key: Array[Byte]): String = {
     val mac = Mac.getInstance("HmacSHA1")


### PR DESCRIPTION
I think in principle this body parser code - which would check if hook callbacks from GitHub are correctly signed with the correct HMAC - is a sensible thing to have - but it's not currently used, and the Play definition of the BodyParser trait has changed since Play 2.4, so fixing it would be work!