### PR TITLE
Use `setup-java` support for sbt-caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,18 @@ on:
       - main
 
 jobs:
-  sbt-build:
+  test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: coursier/cache-action@v6
-      - uses: olafurpg/setup-scala@v11
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup JDK
+        uses: actions/setup-java@v3
         with:
-          java-version: adopt@1.11
+          distribution: temurin
+          java-version: 11
+          cache: sbt
       - name: Build and Test
         env:
           PROUT_GITHUB_ACCESS_TOKEN: ${{ secrets.PROUT_GITHUB_ACCESS_TOKEN }}
-        run: sbt test
+        run: sbt -v test


### PR DESCRIPTION
https://github.com/actions/setup-java#caching-sbt-dependencies

See https://github.com/actions/setup-java/pull/302 - it looks like the sbt-caching functionality was informed by https://github.com/coursier/cache-action (see https://github.com/actions/setup-java/pull/302#discussion_r834292851 ), so `setup-java` may now be the 'best' solution for Scala.
