### PR TITLE
Remove java 8 version reference

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -13,8 +13,5 @@ jobs:
       DEBUG: true
       ORG: guardian-devtools
       SKIP_NODE: true
-      
-      
-      JAVA_VERSION: 8
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## What does this change?

I think the `java 8` reference was needed before dependencies were updated in https://github.com/guardian/prout/commit/8122cd9ff24ca3e77f81f31d00061d7675bf558c
The [runtime properties](https://github.com/guardian/prout/blob/main/system.properties) references `java 11` now.

