### PR TITLE
Check for commit ids in HTTP response headers, as well as response body

### DIFF
--- a/test/lib/CheckpointSpec.scala
+++ b/test/lib/CheckpointSpec.scala
@@ -15,5 +15,17 @@ class CheckpointSpec extends PlaySpec with ScalaFutures with Eventually with Int
         Checkpoint("PROD", CheckpointDetails("https://dashboard.ophan.co.uk/login", Period.parse("PT1H")))
       whenReady(CheckpointSnapshoter.snapshot(checkpoint)) { _ must not be empty }
     }
+
+    // TODO: We add this test once this gets merged: https://github.com/guardian/frontend/pull/25795
+//    "be able to hit the UK network front" in {
+//      val checkpoint =
+//        Checkpoint("CODE", CheckpointDetails("https://m.code.dev-theguardian.com/uk", Period.parse("PT1H")))
+//      whenReady(CheckpointSnapshoter.snapshot(checkpoint)) { gitCommitIds =>
+//        val commitIds = gitCommitIds.toList
+//        println("Git commit ids:" + commitIds)
+//        println(commitIds.length)
+//        commitIds must not be empty
+//      }
+//    }
   }
 }


### PR DESCRIPTION
Action item coming from this retro: https://docs.google.com/document/d/1xNtvBELOISYXyosLO0yKrl3GEQx61lrUvoRbY_Hgedk/edit#heading=h.dnxdemhjrv8p

We want to make sure Prout is checking which commit id is actually running in production. For that reason, we want to be able to read commit ids from frontend which does not always have control over the html, so we want to use response headers instead.

Co-authored-by: Roberto Tyley <roberto.tyley@guardian.co.uk>
Co-authored-by: Georges Lebreton <georges.lebreton@guardian.co.uk>
Co-authored-by: Daniel Clifton <daniel.clifton@guardian.co.uk>

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

We deployed https://github.com/guardian/frontend/pull/25795 in CODE and we were able to get back the commit id in an http response header:

```
x-gu-frontend-git-commit-id: ae26c4dcf0ab33469286e41a19891a77f0f87ed5
```
