### PR TITLE
Add timing for repo snapshots - debug timeouts on scanning guardian/frontend

### DIFF
--- a/app/lib/RepoUtil.scala
+++ b/app/lib/RepoUtil.scala
@@ -34,7 +34,7 @@ object RepoUtil extends Logging {
   def getGitRepo(dataDirectory: File, uri: String, credentials: Option[CredentialsProvider] = None): Repository = {
 
     def invoke[C <: GitCommand[_], R](command: TransportCommand[C, R]): R = {
-      command.setTimeout(5)
+      command.setTimeout(15)
       credentials.foreach(command.setCredentialsProvider)
       command.call()
     }


### PR DESCRIPTION
We're getting timeouts when trying to scan guardian/frontend, and we want to be able diagnose the likely candidates for the cause.
