### PR TITLE
Avoid `OutOfMemoryError`s on guardian/frontend - use shallow clones...?!

### DIFF
--- a/app/lib/RepoUtil.scala
+++ b/app/lib/RepoUtil.scala
@@ -58,7 +58,10 @@ object RepoUtil extends Logging {
       } else {
         Files.createDirectories(gitdir.toPath.getParent)
         logger.info(s"Cloning new Git repo... $uri")
-        invoke(Git.cloneRepository().setBare(true).setDirectory(gitdir).setURI(uri)).getRepository
+        invoke(
+          Git.cloneRepository()
+            .setDepth(200) // the aim here is to reduce the memory load of big repos like guardian/frontend
+            .setBare(true).setDirectory(gitdir).setURI(uri)).getRepository
       }
     }
 


### PR DESCRIPTION
Taking a repo snapshot of the full guardian/frontend repo sometimes gives `java.lang.OutOfMemoryError: Java heap space` exceptions - a very bad exception it's difficult to recover from!

In particular, in this case it seemed to kill the DogPile code, with `Dogpile.doAtLeastOneMore()` _never_ scheduling another scan for guardian/frontend once this error had occurred:

```
Jan 27 06:34:27 prout-bot app/web.1 [info] l.RepoLevelDetails - Need to look at guardian/frontend, branch:main commit AnyObjectId[21b927c00c8f5f09833291b6dbcd5ec93c5db245]
Jan 27 06:34:28 prout-bot app/web.1 java.lang.OutOfMemoryError: Java heap space
Jan 27 06:34:28 prout-bot app/web.1 	at org.eclipse.jgit.internal.storage.file.PackIndexV2.<init>(PackIndexV2.java:94)
Jan 27 06:34:28 prout-bot app/web.1 	at org.eclipse.jgit.internal.storage.file.PackIndex.read(PackIndex.java:101)
Jan 27 06:34:28 prout-bot app/web.1 	at org.eclipse.jgit.internal.storage.file.PackIndex.open(PackIndex.java:67)
Jan 27 06:34:28 prout-bot app/web.1 	at org.eclipse.jgit.internal.storage.file.Pack.idx(Pack.java:160)
Jan 27 06:34:28 prout-bot app/web.1 	at org.eclipse.jgit.internal.storage.file.Pack.get(Pack.java:272)
Jan 27 06:34:28 prout-bot app/web.1 	at org.eclipse.jgit.internal.storage.file.PackDirectory.open(PackDirectory.java:212)
Jan 27 06:34:28 prout-bot app/web.1 	at org.eclipse.jgit.internal.storage.file.ObjectDirectory.openPackedObject(ObjectDirectory.java:405)
Jan 27 06:34:28 prout-bot app/web.1 	at org.eclipse.jgit.internal.storage.file.ObjectDirectory.openPackedFromSelfOrAlternate(ObjectDirectory.java:369)
Jan 27 06:34:28 prout-bot app/web.1 	at org.eclipse.jgit.internal.storage.file.ObjectDirectory.openObjectWithoutRestoring(ObjectDirectory.java:360)
Jan 27 06:34:28 prout-bot app/web.1 	at org.eclipse.jgit.internal.storage.file.ObjectDirectory.openObject(ObjectDirectory.java:345)
Jan 27 06:34:28 prout-bot app/web.1 	at org.eclipse.jgit.internal.storage.file.WindowCursor.open(WindowCursor.java:132)
Jan 27 06:34:28 prout-bot app/web.1 	at org.eclipse.jgit.lib.ObjectReader.open(ObjectReader.java:214)
Jan 27 06:34:28 prout-bot app/web.1 	at org.eclipse.jgit.revwalk.RevWalk.parseAny(RevWalk.java:1081)
Jan 27 06:34:28 prout-bot app/web.1 	at org.eclipse.jgit.revwalk.RevWalk.parseCommit(RevWalk.java:992)
Jan 27 06:34:28 prout-bot app/web.1 	at com.madgag.git.package$RichObjectId.asRevCommit(package.scala:230)
Jan 27 06:34:28 prout-bot app/web.1 	at lib.RepoLevelDetails.mainCommit$lzycompute(RepoSnapshot.scala:151)
Jan 27 06:34:28 prout-bot app/web.1 	at lib.RepoLevelDetails.mainCommit(RepoSnapshot.scala:147)
Jan 27 06:34:28 prout-bot app/web.1 	at lib.RepoLevelDetails.config$lzycompute(RepoSnapshot.scala:154)
Jan 27 06:34:28 prout-bot app/web.1 	at lib.RepoLevelDetails.config(RepoSnapshot.scala:154)
Jan 27 06:34:28 prout-bot app/web.1 	at lib.RepoSnapshot.<init>(RepoSnapshot.scala:166)
Jan 27 06:34:28 prout-bot app/web.1 	at lib.RepoSnapshot$Factory.$anonfun$snapshot$8(RepoSnapshot.scala:88)
Jan 27 06:34:28 prout-bot app/web.1 	at lib.RepoSnapshot$Factory$$Lambda$1615/0x000000010025b040.apply(Unknown Source)
Jan 27 06:34:28 prout-bot app/web.1 	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:467)
Jan 27 06:34:28 prout-bot app/web.1 	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
Jan 27 06:34:28 prout-bot app/web.1 	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
Jan 27 06:34:28 prout-bot app/web.1 	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
Jan 27 06:34:28 prout-bot app/web.1 	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
Jan 27 06:34:28 prout-bot app/web.1 	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
Jan 27 06:34:28 prout-bot app/web.1 	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Jan 27 06:34:28 prout-bot app/web.1 [info] c.m.s.GitHub - guardian/frontend - PRs merged to master size=20
```

Hopefully only cloning a small portion of repo history will help...

See also https://github.com/guardian/frontend/issues/25828


