### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ that value on the production site. The ugly-looking SBT config is:
 ```
 buildInfoKeys := Seq[BuildInfoKey](
       name,
-      BuildInfoKey.constant("gitCommitId", Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse(try {
+        "gitCommitId" -> (Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse (try {
         "git rev-parse HEAD".!!.trim
       } catch {
           case e: Exception => "unknown"


### PR DESCRIPTION
## What has changed?

The need for this change is wonderfully explained by @undergroundquizscene [here]:

(https://github.com/guardian/support-frontend/commit/9253ff8ad0ec848c8aa1d7e0f1c0a552dfb03887#diff-ccb3a3657a9db5067c251be06fca341602e37cd247ef30b4858cc407a2513004)

```
BuildInfoKey.constant here is an implicit, the name of which was changed in [this commit in
2020](https://github.com/sbt/sbt-buildinfo/blob/61539b1b0452f3d24553d0fe2f2bd8ebdd9f914b/src/main/scala/sbtbuildinfo/package.scala#L9).

The change wasn’t included in the changelog. Using a tuple and allowing the implicit conversion to be used should
prevent this erroring again the next time they change the name.

```



