### PR TITLE
Avoid Bootstrap updates from Scala Steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,4 @@
+updates.ignore = [
+  # Need to hold back from Bootstrap 5 due to https://github.com/adrianhurt/play-bootstrap/issues/134
+  { groupId = "org.webjars", artifactId = "bootstrap" }
+]


### PR DESCRIPTION
We need to hold back from Bootstrap 5 due to https://github.com/adrianhurt/play-bootstrap/issues/134 - might need to look at how we can get reasonable presentation without using that extra library.
