### PR TITLE
Remove use of Octicon font

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -5,7 +5,6 @@
     <title>prout - pull request deployment monitor</title>
     <link rel="stylesheet" media="screen" href="@routes.Assets.at("lib/bootstrap/css/bootstrap.min.css")" />
     <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/main.css")">
-    <link rel="stylesheet" href="@routes.Assets.at("lib/octicons/octicons/octicons.css")">
 </head>
 <body>
     <nav class="navbar navbar-inverse" role="navigation">

--- a/app/views/userPages/repo.scala.html
+++ b/app/views/userPages/repo.scala.html
@@ -22,9 +22,9 @@
                 <h3>Permissions for @bot.user.atLogin</h3>
                 <ul>
                     <li><em>push</em> @if(permissions.push) {
-                        <span class="octicon octicon-check"></span>
+                        ✅
                     } else {
-                        <span class="octicon octicon-alert"></span>
+                        ❌
                         Push permission is needed for writing comments and setting labels!
                     }
                      </li>
@@ -32,7 +32,7 @@
             }
             <h3>Config files</h3>
             @if(!proutPresenceQuickCheck) {
-                <span class="octicon octicon-alert"></span>
+                ❌
                 Quick check for @ProutConfigFileName failed!
                 @if(repoSnapshot.config.configByFolder.nonEmpty) {
                     GitHub seems to be returning data different to the Git repo itself...
@@ -44,10 +44,10 @@
             @for((folder, configInFolder) <- repoSnapshot.config.configByFolder) {
                 <li>@configLink(folder) @configInFolder.asOpt match {
                     case None => {
-                        <span class="octicon octicon-alert" title="Invalid Prout JSON"></span>
+                        <span title="Invalid Prout JSON">❌</span>
                     }
                     case Some(validConfig) => {
-                        <span class="octicon octicon-check" title="Parsed as valid Prout JSON"></span>
+                        <span title="Parsed as valid Prout JSON">✅</span>
                         <h5>Checkpoints</h5>
                         <ul>
                             @for(checkpoint <- validConfig.checkpointSet) {
@@ -61,14 +61,12 @@
                                                         Commit Id found : @showCommit(commitId)
                                                     }
                                                     case None => {
-                                                        <span class="octicon octicon-alert"></span>
-                                                        No commit id found
+                                                        ❌ No commit id found
                                                     }
                                                 }
                                             }
                                             case Failure(error) => {
-                                                <span class="octicon octicon-alert"></span>
-                                                Could not read from this url, got @error
+                                                ❌ Could not read from this url, got @error
                                             }
                                         }
                                         @snapshot.checkpoint.details.messages.map { messages =>
@@ -78,8 +76,6 @@
                                                 <li>@status.getClass.getName: <a href="@repoSnapshot.repo.html_url/blob/@repoSnapshot.repo.default_branch/@path">@path</a></li>
                                             }
                                             </ul>
-
-
                                         }
                                     }
                                 </li>
@@ -95,7 +91,7 @@
                             }
                             </ul>
                             @if(sentryApiClientOpt.isEmpty) {
-                                ...but no Sentry credentials are available! <span class="octicon octicon-alert" title="No Sentry Creds"></span>
+                                ...but no Sentry credentials are available! ❌
                             }
                         }
                     }
@@ -107,7 +103,9 @@
             <h3>Merged Pull Requests</h3>
             <ul>
                 @for(prDetail <- diagnostic.prDetails) {
-                    <li><a href="@prDetail.pr.html_url" ><span class="octicon octicon-git-pull-request"></span> #@prDetail.pr.number - @prDetail.pr.title</a>
+                    <li><a href="@prDetail.pr.html_url" >
+                        <svg viewBox="0 0 16 16" width="16" height="16"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"></path></svg>
+                        #@prDetail.pr.number - @prDetail.pr.title</a>
                         <ul>
                         @for(e <- prDetail.everythingByCheckpoint.values) {
                             <li>

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "prout"
 
 version := "1.0-SNAPSHOT"
 
-scalaVersion := "2.13.10"
+scalaVersion := "2.13.11"
 
 updateOptions := updateOptions.value.withCachedResolution(true)
 
@@ -32,7 +32,6 @@ libraryDependencies ++= Seq(
   "com.github.nscala-time" %% "nscala-time" % "2.32.0",
   "io.lemonlabs" %% "scala-uri" % "4.0.3",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-  "org.webjars.bower" % "octicons" % "3.5.0",
   "com.madgag.play-git-hub" %% "core" % "5.10",
   "com.madgag.play-git-hub" %% "testkit" % "5.10" % Test,
   "com.madgag.scala-git" %% "scala-git-test" % "4.6" % Test,


### PR DESCRIPTION
GitHub intially released Octicons, its collection of GitHub icons, as an 'icon font' in [May 2012](https://github.blog/2012-05-09-say-hello-to-octicons/). In [February 2016](https://github.blog/2016-02-22-delivering-octicons-with-svg/), GitHub announced that it was moviong away from releasing its icons as a _font_, instead favouring SVG.

This change updates to Prout to remove usage of the icon font, prompted by a Scala Steward update PR (https://github.com/guardian/prout/pull/106) that updated to later version of the Octicons library that caused all the icons to disappear from the page, as the required CSS & font was no longer present.

The icons have been replaced by emoji (for cross ❌ and tick ✅) and, in the case of the Pull Request symbol, the SVG has been directly copied from https://primer.style/design/foundations/icons/git-pull-request-16 .

