### PR TITLE
Ash/vuln fixes

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.madgag.scalagithub.model.RepoId
 import lib.{Bot, RepoSnapshot}
 import play.api.Logging

--- a/app/controllers/RepoAcceptListService.scala
+++ b/app/controllers/RepoAcceptListService.scala
@@ -1,7 +1,7 @@
 package controllers
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
 import com.madgag.github.Implicits._
 import com.madgag.scalagithub.GitHub
 import com.madgag.scalagithub.model.{Repo, RepoId}

--- a/app/lib/Delayer.scala
+++ b/app/lib/Delayer.scala
@@ -1,6 +1,6 @@
 package lib
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/app/lib/Droid.scala
+++ b/app/lib/Droid.scala
@@ -1,6 +1,6 @@
 package lib
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.madgag.git._
 import com.madgag.scalagithub.GitHub
 import com.madgag.scalagithub.model.RepoId

--- a/app/lib/PRUpdater.scala
+++ b/app/lib/PRUpdater.scala
@@ -1,6 +1,6 @@
 package lib
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.madgag.scalagithub.GitHub
 import com.madgag.scalagithub.commands.CreateComment
 import com.madgag.scalagithub.model.{PullRequest, Repo}

--- a/app/lib/RepoSnapshot.scala
+++ b/app/lib/RepoSnapshot.scala
@@ -16,7 +16,7 @@
 
 package lib
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.madgag.git._
 import com.madgag.github.Implicits._
 import com.madgag.scala.collection.decorators._

--- a/app/lib/RepoUpdater.scala
+++ b/app/lib/RepoUpdater.scala
@@ -1,6 +1,6 @@
 package lib
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.madgag.github.Implicits.{RichFuture, RichSource}
 import com.madgag.scalagithub.GitHub
 import com.madgag.scalagithub.commands.CreateLabel

--- a/app/lib/ScanScheduler.scala
+++ b/app/lib/ScanScheduler.scala
@@ -1,6 +1,6 @@
 package lib
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 
 import java.time.Instant
 import java.time.Instant.now
@@ -11,7 +11,7 @@ import com.madgag.scalagithub.model.RepoId
 import com.madgag.time.Implicits._
 import lib.labels.Seen
 import play.api.Logging
-import play.api.libs.concurrent.Akka
+import play.api.libs.concurrent.Pekko
 
 import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/build.sbt
+++ b/build.sbt
@@ -32,31 +32,23 @@ libraryDependencies ++= Seq(
   "com.github.nscala-time" %% "nscala-time" % "2.32.0",
   "io.lemonlabs" %% "scala-uri" % "4.0.3",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-  "com.madgag.play-git-hub" %% "core" % "5.10",
-  "com.madgag.play-git-hub" %% "testkit" % "5.10" % Test,
+  "com.madgag.play-git-hub" %% "core" % "5.12",
+  "com.madgag.play-git-hub" %% "testkit" % "5.12" % Test,
   "com.madgag.scala-git" %% "scala-git-test" % "4.6" % Test,
   "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
 )
 
 // Overidden transient dependencies for Vulnerability fixes
 libraryDependencies ++= Seq(
-  // Introduced through com.typesafe.play:play_2.13:2.9.0
-  // No newer version of play available yet.
-  "com.typesafe.akka" %% "akka-actor" % "2.8.1",
-  "com.typesafe.akka" %% "akka-actor-typed" % "2.8.1",
-  "com.typesafe.akka" %% "akka-protobuf-v3" % "2.8.1",
-  "com.typesafe.akka" %% "akka-serialization-jackson" % "2.8.1",
-  "com.typesafe.akka" %% "akka-slf4j" % "2.8.1",
-  "com.typesafe.akka" %% "akka-stream" % "2.8.1",
-
   // Introduced through org.webjars:bootstrap:3.4.1
   // Fix available in next major bootstrap version - this will involve a lot of breaking changes however.
   "org.webjars" % "jquery" % "3.6.4",
+)
 
-  // Introduced through com.madgag.play-git-hub:core:5.10
-  // No newer version of play-git-hub available yet.
-  "org.eclipse.jgit" % "org.eclipse.jgit" % "6.6.1.202309021850-r",
-  "com.squareup.okhttp3" % "okhttp" % "3.4.0"
+excludeDependencies ++= Seq(
+  // As of Play 3.0, groupId has changed to org.playframework; exclude transitive dependencies to the old artifacts
+  // play-git-hub still has Play 2.x
+  ExclusionRule(organization = "com.typesafe.play")
 )
 
 routesImport ++= Seq("com.madgag.scalagithub.model._","com.madgag.playgithub.Binders._")

--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,17 @@ libraryDependencies ++= Seq(
   "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
 )
 
+// Overidden transient dependencies for Vulnerability fixes
+libraryDependencies ++= Seq(
+  // Introduced through com.typesafe.play:play_2.13:2.9.0
+  "com.typesafe.akka" %% "akka-actor" % "2.8.1",
+  // Introduced through org.webjars:bootstrap:3.4.1
+  "org.webjars" % "jquery" % "3.6.4",
+  // Introduced through com.madgag.play-git-hub:core:5.10
+  "org.eclipse.jgit" % "org.eclipse.jgit" % "6.6.1.202309021850-r",
+  "com.squareup.okhttp3" % "okhttp" % "4.12.0"
+)
+
 routesImport ++= Seq("com.madgag.scalagithub.model._","com.madgag.playgithub.Binders._")
 
 Compile/doc/sources := Seq.empty

--- a/build.sbt
+++ b/build.sbt
@@ -43,13 +43,20 @@ libraryDependencies ++= Seq(
   // Introduced through com.typesafe.play:play_2.13:2.9.0
   // No newer version of play available yet.
   "com.typesafe.akka" %% "akka-actor" % "2.8.1",
+  "com.typesafe.akka" %% "akka-actor-typed" % "2.8.1",
+  "com.typesafe.akka" %% "akka-protobuf-v3" % "2.8.1",
+  "com.typesafe.akka" %% "akka-serialization-jackson" % "2.8.1",
+  "com.typesafe.akka" %% "akka-slf4j" % "2.8.1",
+  "com.typesafe.akka" %% "akka-stream" % "2.8.1",
+
   // Introduced through org.webjars:bootstrap:3.4.1
   // Fix available in next major bootstrap version - this will involve a lot of breaking changes however.
   "org.webjars" % "jquery" % "3.6.4",
+
   // Introduced through com.madgag.play-git-hub:core:5.10
   // No newer version of play-git-hub available yet.
   "org.eclipse.jgit" % "org.eclipse.jgit" % "6.6.1.202309021850-r",
-  "com.squareup.okhttp3" % "okhttp" % "4.12.0"
+  "com.squareup.okhttp3" % "okhttp" % "3.4.0"
 )
 
 routesImport ++= Seq("com.madgag.scalagithub.model._","com.madgag.playgithub.Binders._")

--- a/build.sbt
+++ b/build.sbt
@@ -32,8 +32,8 @@ libraryDependencies ++= Seq(
   "com.github.nscala-time" %% "nscala-time" % "2.32.0",
   "io.lemonlabs" %% "scala-uri" % "4.0.3",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-  "com.madgag.play-git-hub" %% "core" % "5.12",
-  "com.madgag.play-git-hub" %% "testkit" % "5.12" % Test,
+  "com.madgag.play-git-hub" %% "core" % "6.0",
+  "com.madgag.play-git-hub" %% "testkit" % "6.0" % Test,
   "com.madgag.scala-git" %% "scala-git-test" % "4.6" % Test,
   "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
 )
@@ -43,12 +43,6 @@ libraryDependencies ++= Seq(
   // Introduced through org.webjars:bootstrap:3.4.1
   // Fix available in next major bootstrap version - this will involve a lot of breaking changes however.
   "org.webjars" % "jquery" % "3.6.4",
-)
-
-excludeDependencies ++= Seq(
-  // As of Play 3.0, groupId has changed to org.playframework; exclude transitive dependencies to the old artifacts
-  // play-git-hub still has Play 2.x
-  ExclusionRule(organization = "com.typesafe.play")
 )
 
 routesImport ++= Seq("com.madgag.scalagithub.model._","com.madgag.playgithub.Binders._")

--- a/build.sbt
+++ b/build.sbt
@@ -41,10 +41,13 @@ libraryDependencies ++= Seq(
 // Overidden transient dependencies for Vulnerability fixes
 libraryDependencies ++= Seq(
   // Introduced through com.typesafe.play:play_2.13:2.9.0
+  // No newer version of play available yet.
   "com.typesafe.akka" %% "akka-actor" % "2.8.1",
   // Introduced through org.webjars:bootstrap:3.4.1
+  // Fix available in next major bootstrap version - this will involve a lot of breaking changes however.
   "org.webjars" % "jquery" % "3.6.4",
   // Introduced through com.madgag.play-git-hub:core:5.10
+  // No newer version of play-git-hub available yet.
   "org.eclipse.jgit" % "org.eclipse.jgit" % "6.6.1.202309021850-r",
   "com.squareup.okhttp3" % "okhttp" % "4.12.0"
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

 - Bump Play to 2.9.0 from 2.8.19
 - Override various transient dependency versions

The last vuln is a total pain to fix - it involves updating okhttp to 4.x from 3.x, this should have been easy but `com.madgag.play-git-hub` makes use of an internal OkHttp package which isn't available anymore in okhttp 4.x

## How to test

`sbt compile` compiles fine.

<img width="504" alt="image" src="https://github.com/guardian/prout/assets/21217225/135bd4cb-15ba-4a7e-8566-36994329b92c">


`snyk test` before:

<img width="670" alt="image" src="https://github.com/guardian/prout/assets/21217225/347f83a3-e911-42be-9adc-9cab0c48aace">

`snyk test` after:

<img width="695" alt="image" src="https://github.com/guardian/prout/assets/21217225/58f1979f-7dd9-43a2-af43-0f58db172aa9">