### PR TITLE
Bump logback-classic to 1.4.14

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,8 @@ libraryDependencies ++= Seq(
   "com.github.blemale" %% "scaffeine" % "5.2.1",
   "org.webjars" % "bootstrap" % "3.4.1",
   "com.getsentry.raven" % "raven-logback" % "8.0.3",
+  // Transient dependency of raven-logback 8.0.3. No newer version of raven-logback available.
+  "ch.qos.logback" % "logback-classic" % "1.4.14",
   "com.github.nscala-time" %% "nscala-time" % "2.32.0",
   "io.lemonlabs" %% "scala-uri" % "4.0.3",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bumps logback-classic to 1.4.14. Resolving 4 high vulnerabilities.