### PR TITLE
Include setup-scala step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 11
-          cache: sbt
+      - uses: guardian/setup-scala@v1
       - name: Build and Test
         env:
           PROUT_GITHUB_ACCESS_TOKEN: ${{ secrets.PROUT_GITHUB_ACCESS_TOKEN }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-21.0.5.11.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-java corretto-21.0.5.11.1
+java corretto-11.0.25.9.1


### PR DESCRIPTION
This replaces the setup-java step with setup-scala now that SBT has to be installed as well.

Setting Java version to latest Corretto LTS release.
