### PR TITLE
chore(deps): Update jackson to resolve security warning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,28 @@ Test / testOptions +=
 
 val playGitHubVersion = "7.0.0"
 
+val jacksonVersion         = "2.19.0"
+val jacksonDatabindVersion = "2.19.0"
+
+val jacksonOverrides = Seq(
+  "com.fasterxml.jackson.core"     % "jackson-core",
+  "com.fasterxml.jackson.core"     % "jackson-annotations",
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8",
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310"
+).map(_ % jacksonVersion)
+
+val jacksonDatabindOverrides = Seq(
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
+)
+
+val akkaSerializationJacksonOverrides = Seq(
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor",
+  "com.fasterxml.jackson.module"     % "jackson-module-parameter-names",
+  "com.fasterxml.jackson.module"     %% "jackson-module-scala",
+).map(_ % jacksonVersion)
+
+libraryDependencies ++= jacksonDatabindOverrides ++ jacksonOverrides ++ akkaSerializationJacksonOverrides
+
 libraryDependencies ++= Seq(
   filters,
   ws,


### PR DESCRIPTION
## What does this change?
Follows the advice in https://github.com/orgs/playframework/discussions/11222 to override the version of Jackson that's brought in transitively by Play.

This resolves https://github.com/guardian/prout/security/dependabot/15.

## How to test
The tests ran in CI should suffice.