### PR TITLE
Update to play-git-hub v7.0.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala, BuildInfoPlugin)
 Test / testOptions +=
   Tests.Argument(TestFrameworks.ScalaTest, "-u", s"test-results/scala-${scalaVersion.value}")
 
-val playGitHubVersion = "7.0.0"
+val playGitHubVersion = "7.0.2"
 
 val jacksonVersion         = "2.19.0"
 val jacksonDatabindVersion = "2.19.0"


### PR DESCRIPTION
This update will incorperate:

* https://github.com/rtyley/play-git-hub/pull/12

...which is required for GitHub Apps (see #137).

The CI on _this_ PR, which is prior to #137 being merged, confirms that `x-access-token` also works when accessing the GitHub API using a user's Personal Access Token - as well as working with GitHub Apps.