### PR TITLE
Bump Jackson from 2.19.2 to 2.21.2 to fix GHSA-72hv-8253-57qq

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,15 +20,17 @@ Test / testOptions +=
 
 val playGitHubVersion = "9.0.1"
 
-val jacksonVersion         = "2.19.2"
-val jacksonDatabindVersion = "2.19.2"
+val jacksonVersion             = "2.21.2"
+val jacksonDatabindVersion     = "2.21.2"
+val jacksonAnnotationsVersion  = "2.21"
 
 val jacksonOverrides = Seq(
   "com.fasterxml.jackson.core"     % "jackson-core",
-  "com.fasterxml.jackson.core"     % "jackson-annotations",
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8",
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310"
-).map(_ % jacksonVersion)
+).map(_ % jacksonVersion) ++ Seq(
+  "com.fasterxml.jackson.core"     % "jackson-annotations" % jacksonAnnotationsVersion
+)
 
 val jacksonDatabindOverrides = Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion

--- a/build.sbt
+++ b/build.sbt
@@ -20,17 +20,14 @@ Test / testOptions +=
 
 val playGitHubVersion = "9.0.1"
 
-val jacksonVersion             = "2.21.2"
-val jacksonDatabindVersion     = "2.21.2"
-val jacksonAnnotationsVersion  = "2.21"
+val jacksonVersion         = "2.21.2"
+val jacksonDatabindVersion = "2.21.2"
 
 val jacksonOverrides = Seq(
   "com.fasterxml.jackson.core"     % "jackson-core",
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8",
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310"
-).map(_ % jacksonVersion) ++ Seq(
-  "com.fasterxml.jackson.core"     % "jackson-annotations" % jacksonAnnotationsVersion
-)
+).map(_ % jacksonVersion)
 
 val jacksonDatabindOverrides = Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion


### PR DESCRIPTION
## What does this change?

Bumps Jackson dependencies from 2.19.2 to 2.21.2 to fix GHSA-72hv-8253-57qq