### PR TITLE
Disable all the flakey integration tests

### DIFF
--- a/test/FunctionalSpec.scala
+++ b/test/FunctionalSpec.scala
@@ -1,12 +1,13 @@
-import com.madgag.github.Implicits._
+import com.madgag.github.Implicits.*
 import lib.RepoSnapshot.ClosedPRsMostlyRecentlyUpdated
-import lib._
+import lib.*
 import org.eclipse.jgit.lib.ObjectId.zeroId
-import org.scalatest.{BeforeAndAfterAll, Inside}
+import org.scalatest.{BeforeAndAfterAll, Ignore, Inside}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.postfixOps
 
+@Ignore // until https://github.com/guardian/prout/pull/146 is merged
 class FunctionalSpec extends Helpers with Inside with BeforeAndAfterAll {
 
   val testRepoNamePrefix: String = "prout-test"


### PR DESCRIPTION
As detailed in this PR:

* https://github.com/rtyley/play-git-hub/pull/18

...there are multiple issues affecting the flakiness of Prout's integration tests, and fixing them all involved some pretty big changes to `play-git-hub`, released with v10 of that library:

* https://github.com/rtyley/play-git-hub/releases/tag/v10.0.0

Unfortunately updating Prout to adapt to that new version of `play-git-hub` is a big job, especially the migration from `Future` to `IO` - the PR to do that isn't yet completed:

* https://github.com/guardian/prout/pull/146

...in the meantime, Prout's integration tests are failing frequently:

* https://github.com/guardian/prout/pull/178#issuecomment-4207852768

This change disables Prout's integration tests - we'll just have to double-check after deploy that Prout is still working!
